### PR TITLE
Allow default icons to be used in badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | name | string/bool | `friendly_name` | Override entity `friendly_name`, or `false` to hide
 | unit | string | `unit_of_measurement` | Override entity `unit_of_measurement`
 | toggle | bool | `false` | Display a toggle if supported by domain
-| icon | string/bool | `false` | Display default or custom icon instead of state or attribute value
+| icon | string/bool/null | `false` | Display default or custom icon instead of state or attribute value, use `null` to use HASS default icon
 | state_color | bool | `false` | Enable colored icon when entity is active
 | tap_action | object | *see below* | Custom entity tap action
 | format | string | | Format timestamp value (`relative`, `date`, `time`, `datetime`)

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -125,7 +125,7 @@
 
         renderEntityValue(entity) {
             if (entity.toggle) return this.renderToggle(entity.stateObj);
-            else if (entity.icon) return this.renderIcon(entity);
+            else if (entity.icon !== undefined) return this.renderIcon(entity);
             else if (entity.format) return this.renderTimestamp(entity.value, entity.format);
             else return html`${entity.value}`;
         }


### PR DESCRIPTION
This change allows to use default icons in badges.

Example below will show temperature, battery icon (changing based on value) and battery %

```yaml
title: Devices
type: entities
entities:
  - entity: sensor.some_temperature
    type: 'custom:multiple-entity-row'
    name: Temp sensor
    secondary_info: last-changed
    entities:
      - entity: sensor.some_temperature_battery
        name: false
        icon: null
      - entity: sensor.some_temperature_battery
        name: false
```

Possibly fixes #61 