### PR TITLE
Fix state display for binary_sensor entity with device_class

### DIFF
--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -2,6 +2,9 @@
     const html = LitElement.prototype.html;
     const css = LitElement.prototype.css;
 
+    const UNAVAILABLE = "unavailable";
+    const UNKNOWN = "unknown";
+
     class MultipleEntityRow extends LitElement {
 
         static get properties() {
@@ -231,30 +234,33 @@
         }
 
         entityStateValue(stateObj, unit) {
-            let display;
-            const domain = stateObj.entity_id.substr(0, stateObj.entity_id.indexOf("."));
-
-            if (domain === 'binary_sensor') {
-                if (stateObj.attributes.device_class) {
-                    display = this._hass.localize(`component.${domain}.state.${stateObj.attributes.device_class}.${stateObj.state}`);
-                }
-                if (!display) {
-                    display = this._hass.localize(`component.${domain}.state.${stateObj.state}`);
-                }
-            } else if (unit !== false && (unit || stateObj.attributes.unit_of_measurement) && !['unknown', 'unavailable'].includes(stateObj.state)) {
-                display = `${stateObj.state} ${unit || stateObj.attributes.unit_of_measurement}`;
-            } else if (domain === 'zwave') {
-                display = ['initializing', 'dead'].includes(stateObj.state)
-                    ? this._hass.localize(`state.zwave.query_stage.${stateObj.state}`, 'query_stage', stateObj.attributes.query_stage)
-                    : this._hass.localize(`state.zwave.default.${stateObj.state}`);
-            } else {
-                display = this._hass.localize(`state.${domain}.${stateObj.state}`);
+            if (stateObj.state === UNKNOWN || stateObj.state === UNAVAILABLE) {
+                return this._hass.localize(`state.default.${stateObj.state}`);
             }
 
-            return display ||
-                this._hass.localize(`state.default.${stateObj.state}`) ||
-                this._hass.localize(`component.${domain}.state.${stateObj.state}`) ||
-                stateObj.state;
+            if (unit !== false && (unit || stateObj.attributes.unit_of_measurement)) {
+                return `${stateObj.state} ${unit || stateObj.attributes.unit_of_measurement}`;
+            }
+
+            const domain = stateObj.entity_id.substr(0, stateObj.entity_id.indexOf("."));
+
+            if (domain === 'zwave') {
+                return ['initializing', 'dead'].includes(stateObj.state)
+                    ? this._hass.localize(`state.zwave.query_stage.${stateObj.state}`, 'query_stage', stateObj.attributes.query_stage)
+                    : this._hass.localize(`state.zwave.default.${stateObj.state}`);
+            }
+
+            return (
+                // Return device class translation
+                (stateObj.attributes.device_class &&
+                    this._hass.localize(
+                        `component.${domain}.state.${stateObj.attributes.device_class}.${stateObj.state}`
+                    )) ||
+                // Return default translation
+                this._hass.localize(`component.${domain}.state._.${stateObj.state}`) ||
+                // We don't know! Return the raw state.
+                stateObj.state
+            );
         }
 
         getAction(config, entityId) {

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -236,10 +236,10 @@
 
             if (domain === 'binary_sensor') {
                 if (stateObj.attributes.device_class) {
-                    display = this._hass.localize(`state.${domain}.${stateObj.attributes.device_class}.${stateObj.state}`);
+                    display = this._hass.localize(`component.${domain}.state.${stateObj.attributes.device_class}.${stateObj.state}`);
                 }
                 if (!display) {
-                    display = this._hass.localize(`state.${domain}.default.${stateObj.state}`);
+                    display = this._hass.localize(`component.${domain}.state.${stateObj.state}`);
                 }
             } else if (unit !== false && (unit || stateObj.attributes.unit_of_measurement) && !['unknown', 'unavailable'].includes(stateObj.state)) {
                 display = `${stateObj.state} ${unit || stateObj.attributes.unit_of_measurement}`;


### PR DESCRIPTION
Since upgrading to HA 0.109, `binary_sensor` entities with a `device_class` have stopped showing the device specific state when used with multiple-entity row. Perhaps this is a result of [the localization changes to lovelace](https://www.home-assistant.io/blog/2020/04/29/release-109/).

In the following screenshot, you can see the same entity used in both `multiple-entity-row` as well as a standard `entities` card.

<img width="429" alt="Screen Shot 2020-05-01 at 2 40 35 pm" src="https://user-images.githubusercontent.com/81972/80782483-b9c30d80-8bb9-11ea-960e-d323e6f865cb.png">

This change uses the same logic as [`compute_state_display.ts`](https://github.com/home-assistant/frontend/blob/dev/src/common/entity/compute_state_display.ts#L60) which is used with the core entity displays in Lovelace.

The logic in `entityStateValue()` is a fair bit more complicated than what is used in [`compute_state_display.ts`](https://github.com/home-assistant/frontend/blob/dev/src/common/entity/compute_state_display.ts#L60) - I've updated the code to be more consistent with it. This also now fixes the state value for other types of entities which support the `device_class` attribute, such as `cover`.

Fixes #73 
