### PR TITLE
new format option: elapsed

### DIFF
--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -118,7 +118,9 @@
 
         renderTimestamp(value, format) {
             return ![UNKNOWN, UNAVAILABLE].includes(value.toLowerCase())
-                ? html`<hui-timestamp-display .ts=${new Date(value)} .format=${format} .hass=${this._hass}></hui-timestamp-display>`
+                ? format.toLowerCase() === "elapsed" 
+                    ? html`<div>${parseInt(value/3600).toString().padStart(2,'0')}:${parseInt((value % 3600)/60).toString().padStart(2,'0')}</div>`
+                    : html`<hui-timestamp-display .ts=${new Date(value)} .format=${format} .hass=${this._hass}></hui-timestamp-display>`
                 : html`${value}`;
         }
 


### PR DESCRIPTION
This solves a case where I have a value in seconds but need HH:MM displayed. The specific case is time_remaining attribute on a sprinkler zone.

I was going to revise the readme.md too, but for some reason GitHub keeps blanking the entire view when I try to edit it. I guess you'll have to update that if you merge my change.