### PR TITLE
Add layout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This card produces an `entity-row` and must therefore be configured as an entity
 | entities | list | *see below* | Additional entity IDs or entity object(s)
 | secondary_info | string/object | *see below* | Custom `secondary_info` entity object
 | tap_action | object | *see below* | Custom tap action on main entity state
+| column | bool | | Whether entities should be shown in a column instead of a row
 
 ### Entity Objects
 

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -83,6 +83,7 @@
             display: flex;
             align-items: flex-end;
             min-width: 0;
+            justify-content: space-evenly;
         }`;
         }
 

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -81,7 +81,7 @@
           .entities-column {
             flex-direction: column;
             display: flex;
-            align-items: right;
+            align-items: flex-end;
             min-width: 0;
         }`;
         }

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -73,7 +73,23 @@
           }
           .icon-small {
             width: auto;
-          }`;
+          }
+          .entities-row {
+            flex-direction: row;
+            display: inline-flex;
+            justify-content: space-between;
+            align-items: center;
+            min-width: 0;
+            gap: 8px;
+          }
+          .entities-column {
+            flex-direction: column;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            min-width: 0;
+            gap: 16px;
+        }`;
         }
 
         render() {
@@ -89,12 +105,16 @@
                     ${this.state.name}
                     <div class="secondary">${this.renderSecondaryInfo()}</div>
                 </div>
-                ${this.state.entities.map(entity => this.renderEntity(entity))}
-                ${this.state.value ? html`
-                <div class="state entity" @click="${this.onStateClick}">
-                    ${this.stateHeader && html`<span>${this.stateHeader}</span>`}
-                    ${this.renderMainState()}
-                </div>` : null}
+                <div class="${
+                    this._config.column ? "entities-column" : "entities-row"
+                }">
+                    ${this.state.entities.map(entity => this.renderEntity(entity))}
+                    ${this.state.value ? html`
+                    <div class="state entity" @click="${this.onStateClick}">
+                        ${this.stateHeader && html`<span>${this.stateHeader}</span>`}
+                        ${this.renderMainState()}
+                    </div>` : null}
+                </div>
             </div>`;
         }
 

--- a/multiple-entity-row.js
+++ b/multiple-entity-row.js
@@ -54,16 +54,12 @@
             cursor: pointer;
           }
           .entity {
-            margin-right: 16px;
             text-align: center;
             cursor: pointer;
           }
           .entity span {
             font-size: 10px;
             color: var(--secondary-text-color);
-          }
-          .entity:last-of-type {
-            margin-right: 0;
           }
           .state {
             min-width: 45px;
@@ -80,15 +76,13 @@
             justify-content: space-between;
             align-items: center;
             min-width: 0;
-            gap: 8px;
+            gap: 16px;
           }
           .entities-column {
             flex-direction: column;
             display: flex;
-            justify-content: space-between;
-            align-items: center;
+            align-items: right;
             min-width: 0;
-            gap: 16px;
         }`;
         }
 


### PR DESCRIPTION
This PR adds a "column" boolean config option to the entity row definition. When enabled, entities in that row will be shown in a column rather than a row.

To enable this I had to make a few supporting changes:
- Wrapped the entities in a parent div
- Change to using flex css "gap" instead of margins because `entity:last-of-type { margin-right: 0; }` is not a viable solution when things may be arranged in a column.

I tested a couple of different cards with different settings and these changes didn't affect the layout of those at all, but given the flexibility of this card there may well be some combinations that will be affected.

Also, the "gap" property is super new, so bear that in mind.



