### PR TITLE
Add a theme variable to control a header's color

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -8,7 +8,7 @@ export const style = (css) => css`
     }
     .entity span {
         font-size: 10px;
-        color: var(--secondary-text-color);
+        color: var(--multiple-entity-row-header-color, var(--secondary-text-color));
     }
     .entities-row {
         flex-direction: row;


### PR DESCRIPTION
The new `--multiple-entity-row-header-color` variable may be ether defined in a custom theme - or defined locally:
```
- entity: sun.sun
  name: our sun
  styles:
    '--multiple-entity-row-header-color': red
```