### PR TITLE
Fix icons for HA 2024.2+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,7 @@ class MultipleEntityRow extends LitElement {
     renderIcon(stateObj, config) {
         return html`<state-badge
             class="icon-small"
+            .hass=${this._hass}
             .stateObj="${stateObj}"
             .overrideIcon="${config.icon === true ? stateObj.attributes.icon || null : config.icon}"
             .stateColor="${config.state_color}"


### PR DESCRIPTION
Due to changes in the Home Assistant Frontend, the `state-badge` need to be updated to send a `.hass` property.

This fixes #330 