### PR TITLE
add option to display an entity value as an icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | toggle           | bool        | `false`                     | Display a toggle if supported by domain                            |
 | icon             | string/bool | `false`                     | Display default or custom icon instead of state or attribute value |
 | state_color      | bool        | `false`                     | Enable colored icon when entity is active                          |
+| icon             | bool        | `false`                     | Display value as icon (use with `state_color` for coloured icon)   |
 | default          | string      |                             | Display this value if the entity does not exist or should not be shown |
 | hide_unavailable | bool        | `false`                     | Hide entity if unavailable or not found                            |
 | hide_if          | object/any  | _[Hiding](#hiding)_         | Hide entity if its value matches specified value or criteria       |

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,22 @@ class MultipleEntityRow extends LitElement {
             return null;
         }
         const onClick = this.clickHandler(stateObj.entity_id, config.tap_action);
+
+        if (config.icon === true) {
+            return html`<div class="entity" style="${entityStyles(config)}" @click="${onClick}">
+                <span>${entityName(stateObj, config)}</span>
+                <div>
+                    <state-badge
+                        class="icon-small"
+                        .hass=${this._hass}
+                        .stateObj="${stateObj}"
+                        .overrideIcon="${stateObj.attributes.icon || null}"
+                        .stateColor="${config.state_color}"
+                    ></state-badge>
+                </div>
+            </div>`;
+        }
+
         return html`<div class="entity" style="${entityStyles(config)}" @click="${onClick}">
             <span>${entityName(stateObj, config)}</span>
             <div>${config.icon ? this.renderIcon(stateObj, config) : this.renderValue(stateObj, config)}</div>


### PR DESCRIPTION
It could be useful (and prettier) to display en entity value as its icon (e.g. battery levels).

## Old behavior (without PR)

Configuration example:
```yml
type: entities
title: Capteurs de contact
entities:
  - entity: binary_sensor.porte_cuisine_sous_sol
    type: custom:multiple-entity-row
    entities:
      - entity: sensor.porte_cuisine_sous_sol_battery
        name: false
  - entity: binary_sensor.porte_d_entree
    type: custom:multiple-entity-row
    entities:
      - entity: sensor.porte_d_entree_battery
        name: false
```
Screenshot: 
![image](https://github.com/user-attachments/assets/a525121a-4544-4f1a-a0c6-448005dcd898)

## New behavior (without PR)

Configuration example: 
```yml
type: entities
title: Capteurs de contact
entities:
  - entity: binary_sensor.porte_cuisine_sous_sol
    type: custom:multiple-entity-row
    entities:
      - entity: sensor.porte_cuisine_sous_sol_battery
        name: false
        icon: true
        state_color: true
  - entity: binary_sensor.porte_d_entree
    type: custom:multiple-entity-row
    entities:
      - entity: sensor.porte_d_entree_battery
        name: false
        icon: true
        state_color: true
```
Screenshot: 
![image](https://github.com/user-attachments/assets/57dab497-3761-4552-8de5-d3954cdcfd91)
