### PR TITLE
Fix: duration format shows "null" for a zero-second value (#240)

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -44,13 +44,15 @@ export const entityStateDisplay = (hass, stateObj, config) => {
             value = Math.round((value / 255) * 100);
             unit = '%';
         } else if (config.format === 'duration') {
-            value = secondsToDuration(value);
+            // secondsToDuration returns null for a zero duration; fall back to '0'
+            // so the template literal below doesn't render the literal string "null".
+            value = secondsToDuration(value) ?? '0';
             unit = undefined;
         } else if (config.format === 'duration-m') {
-            value = secondsToDuration(value / 1000);
+            value = secondsToDuration(value / 1000) ?? '0';
             unit = undefined;
         } else if (config.format === 'duration-h') {
-            value = secondsToDuration(value * 3600);
+            value = secondsToDuration(value * 3600) ?? '0';
             unit = undefined;
         } else if (config.format.startsWith('precision')) {
             const precision = parseInt(config.format.slice(-1), 10);

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -78,11 +78,19 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { attribute: 'brightness', format: 'brightness' })).toBe('50 %');
     });
 
-    // See https://github.com/benct/lovelace-multiple-entity-row/issues/240 -
-    // duration format must not print "null" when there is nothing to show.
     it('applies the duration format', () => {
         const stateObj = { state: '90', attributes: {} };
         expect(entityStateDisplay(hass, stateObj, { format: 'duration' })).toBe('1:30');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/240 -
+    // a zero duration must render as '0', not the literal string "null"
+    // (secondsToDuration returns null for zero seconds by design).
+    it('renders a zero duration as 0, not "null"', () => {
+        const stateObj = { state: '0', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'duration' })).toBe('0');
+        expect(entityStateDisplay(hass, stateObj, { format: 'duration-m' })).toBe('0');
+        expect(entityStateDisplay(hass, stateObj, { format: 'duration-h' })).toBe('0');
     });
 
     it('applies the precision format with the requested digit count', () => {


### PR DESCRIPTION
## Summary
- `secondsToDuration()` returns `null` for a zero-second duration by design (it's a direct port of Home Assistant frontend's own helper — see the file's source comment). `entity.js`'s duration formatting interpolated that `null` straight into a template literal, rendering the literal string `"null"` in the UI instead of a sensible zero value.
- Affects all three duration formats (`duration`, `duration-m`, `duration-h`), since they all route through the same `secondsToDuration` helper.
- Fixed at the display layer (`entity.js`) rather than changing `secondsToDuration`'s return value, to keep it in sync with upstream HA semantics if this file is ever re-synced.

Fixes #240

## Test plan
- [x] Added a regression test covering all three duration formats at zero seconds (`src/entity.test.js`)
- [x] `yarn build` (lint + 97 tests + webpack) passes clean
- [x] Confirmed `secondsToDuration(0)` still correctly returns `null` (unchanged) — the fix is purely at the point where that value gets rendered