### PR TITLE
Fix name override not applying on main row in HA 2026.2+ (#370, #371)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -52,6 +52,12 @@ export const hasConfigOrEntitiesChanged = (node, changedProps) => {
 
     const oldHass = changedProps.get('_hass');
     if (oldHass) {
+        // HA installs a stub `formatEntityName` that ignores the name override on initial connection
+        // and replaces it asynchronously once translations load. Re-render when that swap happens so
+        // the `name` override actually takes effect on the main row.
+        if (oldHass.formatEntityName !== node._hass.formatEntityName) {
+            return true;
+        }
         return node.entityIds.some((entity) => oldHass.states[entity] !== node._hass.states[entity]);
     }
     return false;

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -140,4 +140,22 @@ describe('hasConfigOrEntitiesChanged', () => {
         const changedProps = new Map([['_hass', oldHass]]);
         expect(hasConfigOrEntitiesChanged(node, changedProps)).toBe(false);
     });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/370 and
+    // https://github.com/benct/lovelace-multiple-entity-row/issues/371 - HA 2026.2+ installs a stub
+    // `formatEntityName` on initial connection and swaps in the real implementation asynchronously
+    // once translations load. A `name` override wouldn't take effect until some unrelated entity
+    // state changed forced a re-render, because this swap alone wasn't treated as a change.
+    it('is true when hass swaps in a new formatEntityName implementation', () => {
+        const sharedState = { state: 'on' };
+        const stubFormatEntityName = () => 'stub';
+        const realFormatEntityName = () => 'real';
+        const oldHass = { states: { 'sensor.a': sharedState }, formatEntityName: stubFormatEntityName };
+        const node = {
+            entityIds: ['sensor.a'],
+            _hass: { states: { 'sensor.a': sharedState }, formatEntityName: realFormatEntityName },
+        };
+        const changedProps = new Map([['_hass', oldHass]]);
+        expect(hasConfigOrEntitiesChanged(node, changedProps)).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary
HA 2026.2+ resolves entity row names via `hass.formatEntityName(stateObj, config.name)`. On initial connection HA installs a stub (`src/state/connection-mixin.ts`) that ignores the second argument and returns the friendly name; the real implementation is swapped in asynchronously by `state-display-mixin` once translations load.

`hasConfigOrEntitiesChanged` only re-rendered when a watched entity's state changed, so a `name:` override wouldn't take effect until some unrelated entity state change happened to force a re-render. This detects the `formatEntityName` swap itself (by reference identity) and forces a re-render when it happens.

This is a rebase of #373 onto current master — same diagnosis and fix, originally by @d3relict — with the stale committed-bundle/version-bump diff dropped (now handled by CI/release automation, see #377) and a regression test added.

Fixes #370, fixes #371

## Test plan
- [x] Added a regression test simulating the `formatEntityName` stub → real-implementation swap (`src/util.test.js`)
- [x] `yarn build` (lint + 98 tests + webpack) passes clean