### PR TITLE
Use HA's official entity formatting functions when available

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -25,8 +25,16 @@ export const entityName = (stateObj, config) => {
 };
 
 export const entityStateDisplay = (hass, stateObj, config) => {
+    // HA 2023.9+ exposes hass.formatEntityState/formatEntityAttributeValue, which apply the
+    // user's own locale/number-format/precision preferences the same way HA's own UI does.
+    // Prefer them over our own formatNumber/computeStateDisplay reimplementation when present.
+    const hasOfficialStateFormatter = typeof hass.formatEntityState === 'function';
+    const hasOfficialAttributeFormatter = typeof hass.formatEntityAttributeValue === 'function';
+
     if (isUnavailable(stateObj)) {
-        return hass.localize(`state.default.${stateObj.state}`);
+        return hasOfficialStateFormatter
+            ? hass.formatEntityState(stateObj)
+            : hass.localize(`state.default.${stateObj.state}`);
     }
 
     let value = config.attribute ? stateObj.attributes[config.attribute] : stateObj.state;
@@ -74,13 +82,17 @@ export const entityStateDisplay = (hass, stateObj, config) => {
         return `${value}${unit ? ` ${unit}` : ''}`;
     }
 
-    if (config.attribute) {
-        return `${isNaN(value) ? value : formatNumber(value, hass.locale)}${unit ? ` ${unit}` : ''}`;
-    }
-
     const modifiedStateObj = { ...stateObj, attributes: { ...stateObj.attributes, unit_of_measurement: unit } };
 
-    return computeStateDisplay(hass.localize, modifiedStateObj, hass.locale, hass.entities);
+    if (config.attribute) {
+        return hasOfficialAttributeFormatter
+            ? hass.formatEntityAttributeValue(modifiedStateObj, config.attribute)
+            : `${isNaN(value) ? value : formatNumber(value, hass.locale)}${unit ? ` ${unit}` : ''}`;
+    }
+
+    return hasOfficialStateFormatter
+        ? hass.formatEntityState(modifiedStateObj)
+        : computeStateDisplay(hass.localize, modifiedStateObj, hass.locale, hass.entities);
 };
 
 export const entityStyles = (config) =>

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -117,6 +117,39 @@ describe('entityStateDisplay', () => {
         const stateObj = { entity_id: 'sensor.temp', state: '21', attributes: { unit_of_measurement: '°C' } };
         expect(entityStateDisplay(hass, stateObj, {})).toBe('21 °C');
     });
+
+    // See https://developers.home-assistant.io/docs/frontend/data#entity-state-formatting -
+    // HA 2023.9+ exposes hass.formatEntityState/formatEntityAttributeValue, which apply the user's
+    // own locale/precision preferences. Prefer these over our own reimplementation when present.
+    describe('with HA official formatting functions available', () => {
+        const officialHass = {
+            ...hass,
+            formatEntityState: vi.fn((stateObj) => `official-state:${stateObj.state}`),
+            formatEntityAttributeValue: vi.fn((stateObj, attribute) => `official-attr:${attribute}`),
+        };
+
+        it('delegates unavailable-state localization to formatEntityState', () => {
+            const stateObj = { state: 'unavailable', attributes: {} };
+            expect(entityStateDisplay(officialHass, stateObj, {})).toBe('official-state:unavailable');
+        });
+
+        it('delegates attribute display to formatEntityAttributeValue', () => {
+            const stateObj = { state: 'on', attributes: { battery_level: 42 } };
+            expect(entityStateDisplay(officialHass, stateObj, { attribute: 'battery_level' })).toBe(
+                'official-attr:battery_level'
+            );
+        });
+
+        it('delegates main state display to formatEntityState', () => {
+            const stateObj = { entity_id: 'sensor.temp', state: '21', attributes: {} };
+            expect(entityStateDisplay(officialHass, stateObj, {})).toBe('official-state:21');
+        });
+
+        it('still applies a custom format instead of the official formatters', () => {
+            const stateObj = { state: '90', attributes: {} };
+            expect(entityStateDisplay(officialHass, stateObj, { format: 'duration' })).toBe('1:30');
+        });
+    });
 });
 
 describe('entityStyles', () => {

--- a/src/util.js
+++ b/src/util.js
@@ -45,6 +45,13 @@ export const getEntityIds = (config) =>
         .concat(config.entities?.map((entity) => (typeof entity === 'string' ? entity : entity.entity)))
         .filter((entity) => entity);
 
+// HA installs stub formatEntityName/formatEntityState/formatEntityAttributeValue functions on
+// initial connection (returning raw, unformatted values) and replaces them asynchronously with
+// the real implementations once translations load. None of that swap is otherwise observable, so
+// without this check a row can get stuck showing stale/raw output until some unrelated entity
+// state change happens to force a re-render.
+const HASS_FORMATTER_KEYS = ['formatEntityName', 'formatEntityState', 'formatEntityAttributeValue'];
+
 export const hasConfigOrEntitiesChanged = (node, changedProps) => {
     if (changedProps.has('config')) {
         return true;
@@ -52,10 +59,7 @@ export const hasConfigOrEntitiesChanged = (node, changedProps) => {
 
     const oldHass = changedProps.get('_hass');
     if (oldHass) {
-        // HA installs a stub `formatEntityName` that ignores the name override on initial connection
-        // and replaces it asynchronously once translations load. Re-render when that swap happens so
-        // the `name` override actually takes effect on the main row.
-        if (oldHass.formatEntityName !== node._hass.formatEntityName) {
+        if (HASS_FORMATTER_KEYS.some((key) => oldHass[key] !== node._hass[key])) {
             return true;
         }
         return node.entityIds.some((entity) => oldHass.states[entity] !== node._hass.states[entity]);

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -142,20 +142,23 @@ describe('hasConfigOrEntitiesChanged', () => {
     });
 
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/370 and
-    // https://github.com/benct/lovelace-multiple-entity-row/issues/371 - HA 2026.2+ installs a stub
-    // `formatEntityName` on initial connection and swaps in the real implementation asynchronously
-    // once translations load. A `name` override wouldn't take effect until some unrelated entity
-    // state changed forced a re-render, because this swap alone wasn't treated as a change.
-    it('is true when hass swaps in a new formatEntityName implementation', () => {
-        const sharedState = { state: 'on' };
-        const stubFormatEntityName = () => 'stub';
-        const realFormatEntityName = () => 'real';
-        const oldHass = { states: { 'sensor.a': sharedState }, formatEntityName: stubFormatEntityName };
-        const node = {
-            entityIds: ['sensor.a'],
-            _hass: { states: { 'sensor.a': sharedState }, formatEntityName: realFormatEntityName },
-        };
-        const changedProps = new Map([['_hass', oldHass]]);
-        expect(hasConfigOrEntitiesChanged(node, changedProps)).toBe(true);
-    });
+    // https://github.com/benct/lovelace-multiple-entity-row/issues/371 - HA 2026.2+ installs stub
+    // formatEntityName/formatEntityState/formatEntityAttributeValue functions on initial connection
+    // (returning raw, unformatted values) and swaps in the real implementations asynchronously once
+    // translations load. Without detecting that swap, a row can get stuck showing stale/raw output
+    // (e.g. a `name` override reverting, or a numeric state showing unformatted) until some
+    // unrelated entity state change happens to force a re-render.
+    it.each(['formatEntityName', 'formatEntityState', 'formatEntityAttributeValue'])(
+        'is true when hass swaps in a new %s implementation',
+        (key) => {
+            const sharedState = { state: 'on' };
+            const oldHass = { states: { 'sensor.a': sharedState }, [key]: () => 'stub' };
+            const node = {
+                entityIds: ['sensor.a'],
+                _hass: { states: { 'sensor.a': sharedState }, [key]: () => 'real' },
+            };
+            const changedProps = new Map([['_hass', oldHass]]);
+            expect(hasConfigOrEntitiesChanged(node, changedProps)).toBe(true);
+        }
+    );
 });


### PR DESCRIPTION
## Summary
HA 2023.9+ exposes `hass.formatEntityState`/`hass.formatEntityAttributeValue`, which apply the user's own locale/number-format/precision preferences the same way HA's own UI does. This delegates to them when present instead of this project's own `formatNumber`/`computeStateDisplay` reimplementation, falling back to the existing logic otherwise. A custom `format:` config still takes precedence over both.

Based on the approach in #336 (originally by @mill1000), which should close #333, #308, #286, and #220 — a cluster of long-standing decimal/precision formatting complaints.

## A regression #336 would have introduced, and how this fixes it

HA installs stub `formatEntityState`/`formatEntityAttributeValue` functions on initial connection that return completely raw, unformatted values (confirmed by extracting the actual implementations from a running instance's frontend bundle — the stub is literally `(e,t) => (t ?? e.state) ?? ""`), then swaps in the real implementations asynchronously once translations load.

This is the same race #373/#379 fixed for `formatEntityName` — except #336 didn't extend that re-render check to the new functions it now depends on, so cards would have gotten stuck showing raw values whenever the swap happened after initial render (same bug class as #370/#371, but for values instead of names).

Generalized `hasConfigOrEntitiesChanged`'s `formatEntityName` check into a list covering all three formatter keys, and added tests simulating the swap for each.

Fixes #333, fixes #308, fixes #286, fixes #220

## Test plan
- [x] Added tests covering the new delegation paths in `entityStateDisplay` (the original PR's diff had zero coverage of this)
- [x] Added tests simulating the stub→real swap for all three `hass` formatter functions
- [x] `yarn build` (lint + 104 tests + webpack) passes clean
- [x] **Live-verified in a local HA testbed** (real HA instance, not just unit tests): default-precision numeric rows now match HA's own displayed precision exactly, an explicit `format: precision<N>` override still takes priority as expected, and no raw/unformatted flash on reload