### PR TITLE
Fix: numeric formats show "undefined" for a missing attribute (#225)

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -46,6 +46,13 @@ export const entityStateDisplay = (hass, stateObj, config) => {
             : config.unit || stateObj.attributes.unit_of_measurement;
 
     if (config.format) {
+        // A missing attribute (e.g. brightness/color_temp on a light that's off) is undefined,
+        // not a number - treat it as 0 rather than letting it flow through to the final template
+        // literal below as the literal string "undefined" (see #225). A value that's some other
+        // non-numeric type (e.g. a genuine text attribute) is left untouched, same as before.
+        if (value === undefined || value === null) {
+            value = 0;
+        }
         if (isNaN(parseFloat(value)) || !isFinite(value)) {
             // do nothing if not a number
         } else if (config.format === 'brightness') {

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -113,6 +113,15 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { format: 'precision2' })).toBe('not-a-number');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/225 -
+    // a missing attribute (e.g. brightness/color_temp on a light that's off) must render as a
+    // sensible zero value, not the literal string "undefined".
+    it('treats a missing attribute as 0 for a numeric format, instead of "undefined"', () => {
+        const stateObj = { state: 'off', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { attribute: 'brightness', format: 'brightness' })).toBe('0 %');
+        expect(entityStateDisplay(hass, stateObj, { attribute: 'color_temp', format: 'precision0' })).toBe('0');
+    });
+
     it('falls back to computeStateDisplay for the main state with no attribute or format', () => {
         const stateObj = { entity_id: 'sensor.temp', state: '21', attributes: { unit_of_measurement: '°C' } };
         expect(entityStateDisplay(hass, stateObj, {})).toBe('21 °C');


### PR DESCRIPTION
## Summary
When a formatted attribute is missing from the entity (e.g. `brightness` or `color_temp` on a light that's off), `value` was `undefined`, which skipped every format branch (the `isNaN`/`isFinite` guard treats it as non-numeric) and flowed straight through to the final template literal, rendering the literal string `"undefined"` — same failure mode as #240's `"null"` duration bug, but for any numeric format (`brightness`, `precision<N>`, `kilo`, `invert`, `position`, `celsius_to_fahrenheit`/`fahrenheit_to_celsius`), not just brightness.

Treats a missing (`undefined`/`null`) value as `0` before the format dispatch, matching the "0%"/"0" behavior requested throughout the issue thread. A genuinely non-numeric value that IS present (e.g. a text attribute) is left untouched, same as before.

Fixes #225

## Test plan
- [x] Added regression tests covering both the brightness format and a generic precision format against a missing attribute
- [x] `yarn build` (lint + 105 tests + webpack) passes clean
- [x] **Live-verified in a local HA testbed**: `light.bed_light` off → `brightness`/`color_temp` rows now show `0 %`/`0` instead of the literal word `undefined`; turning the light back on restores real values