### PR TITLE
Fix precision loss in invert/position; add kilo/mega/milli<0-9> (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,24 @@ The `format` option supports the following values:
 | duration-m            | `number`    | Convert number of milliseconds to duration (`5:38:50`)           |
 | duration-h            | `number`    | Convert number of hours to duration (`5:38:50`)                  |
 | invert                | `number`    | Convert number from positive to negative or vice versa           |
-| kilo                  | `number`    | Divide number value by 1000 (ex. `1500 W` -> `1.5 kW`)           |
+| kilo / kilo<0-9>      | `number`    | Divide number value by 1,000 (ex. `1500` -> `1.5`)               |
+| mega / mega<0-9>      | `number`    | Divide number value by 1,000,000 (ex. `2500000` -> `2.5`)        |
+| milli / milli<0-9>    | `number`    | Multiply number value by 1,000 (ex. `0.2` -> `200`)              |
 | position              | `number`    | Reverses a position percentage (ex. `70%` open -> `30%` closed)  |
 | precision<0-9>        | `number`    | Set decimal precision of number value (`precision3` -> `18.123`) |
 | celsius_to_fahrenheit | `number`    | Converts a Celsius temperature to its Fahrenheit equivalent      |
 | fahrenheit_to_celsius | `number`    | Converts a Fahrenheit temperature to its Celsius equivalent      |
+
+`kilo`/`mega`/`milli` on their own default to a maximum of 2 decimal places. Suffix a digit (`kilo3`, `mega1`, `milli0`, ...) to request an exact decimal precision instead, the same way `precision<0-9>` does.
+
+None of `kilo`/`mega`/`milli`/`invert`/`position` change the displayed unit — they only scale or transform the number. If you want the unit label to match (e.g. `W` -> `kW`), set `unit:` explicitly alongside the format:
+
+```yaml
+- entity: sensor.power_usage
+  type: custom:multiple-entity-row
+  format: kilo
+  unit: kW
+```
 
 ### Hiding
 

--- a/src/entity.js
+++ b/src/entity.js
@@ -15,6 +15,24 @@ export const checkEntity = (config) => {
 
 export const computeEntity = (entityId) => entityId.substr(entityId.indexOf('.') + 1);
 
+// Decimal digit count of a raw string value (e.g. "1.2345" -> 4), or undefined if value isn't a
+// string with a decimal point. Used to preserve a source value's precision through a
+// scale/sign transform, since arithmetic (e.g. `value / 1000`) coerces the string to a number
+// before it reaches formatNumber, losing the "keep original decimal digits" behavior it would
+// otherwise apply (see #304).
+const decimalDigits = (value) => (typeof value === 'string' && value.includes('.') ? value.split('.')[1].length : undefined);
+
+// Shared implementation for the kilo/mega/milli formats: divides by the given factor, and applies
+// either the default 2-decimal cap (bare `kilo`/`mega`/`milli`, unchanged from prior behavior) or
+// an explicit user-requested precision (`kilo3`, `mega1`, `milli0`, ...).
+const scaledFormat = (value, divisor, digitSuffix, locale) => {
+    if (digitSuffix === '') {
+        return formatNumber(value / divisor, locale, { maximumFractionDigits: 2 });
+    }
+    const precision = parseInt(digitSuffix, 10);
+    return formatNumber(value / divisor, locale, { minimumFractionDigits: precision, maximumFractionDigits: precision });
+};
+
 export const entityName = (stateObj, config) => {
     if (config.name === false) return null;
     return (
@@ -75,12 +93,26 @@ export const entityStateDisplay = (hass, stateObj, config) => {
                 minimumFractionDigits: precision,
                 maximumFractionDigits: precision,
             });
-        } else if (config.format === 'kilo') {
-            value = formatNumber(value / 1000, hass.locale, { maximumFractionDigits: 2 });
+        } else if (config.format.startsWith('kilo')) {
+            value = scaledFormat(value, 1000, config.format.slice(4), hass.locale);
+        } else if (config.format.startsWith('mega')) {
+            value = scaledFormat(value, 1000000, config.format.slice(4), hass.locale);
+        } else if (config.format.startsWith('milli')) {
+            value = scaledFormat(value, 1 / 1000, config.format.slice(5), hass.locale);
         } else if (config.format === 'invert') {
-            value = formatNumber(value - value * 2, hass.locale);
+            const precision = decimalDigits(value);
+            value = formatNumber(
+                value - value * 2,
+                hass.locale,
+                precision !== undefined ? { minimumFractionDigits: precision, maximumFractionDigits: precision } : undefined
+            );
         } else if (config.format === 'position') {
-            value = formatNumber(100 - value, hass.locale);
+            const precision = decimalDigits(value);
+            value = formatNumber(
+                100 - value,
+                hass.locale,
+                precision !== undefined ? { minimumFractionDigits: precision, maximumFractionDigits: precision } : undefined
+            );
         } else if (config.format === 'celsius_to_fahrenheit') {
             value = formatNumber(value * 1.8 + 32, hass.locale, { maximumFractionDigits: 0 });
         } else if (config.format === 'fahrenheit_to_celsius') {

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -108,6 +108,47 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { format: 'position' })).toBe('70');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/304 -
+    // invert/position do arithmetic on the value before formatting, which coerces a string state
+    // to a number and loses formatNumber's "preserve the source string's decimal digits" handling.
+    // The formatted result must keep the same precision as the unformatted source value.
+    it('preserves source precision for the invert format', () => {
+        const stateObj = { state: '1.2345', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'invert' })).toBe('-1.2345');
+    });
+
+    it('preserves source precision for the position format', () => {
+        const stateObj = { state: '30.5', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'position' })).toBe('69.5');
+    });
+
+    it('applies the kilo format with the default 2-decimal cap', () => {
+        const stateObj = { state: '1500.256', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'kilo' })).toBe('1.5');
+    });
+
+    it('applies the mega format with the default 2-decimal cap', () => {
+        const stateObj = { state: '2500000', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'mega' })).toBe('2.5');
+    });
+
+    it('applies the milli format with the default 2-decimal cap', () => {
+        const stateObj = { state: '0.2', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'milli' })).toBe('200');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/304 -
+    // kilo<0-9>/mega<0-9>/milli<0-9> let the user request an explicit precision instead of the
+    // default 2-decimal cap. Also covers a regression in an earlier draft of this feature, which
+    // parsed the trailing digit with radix 5 instead of 10 - silently breaking digits 5-9.
+    it('applies kilo/mega/milli with an explicit requested precision, including digits 5-9', () => {
+        const stateObj = { state: '1500.256789', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'kilo3' })).toBe('1.500');
+        expect(entityStateDisplay(hass, stateObj, { format: 'kilo7' })).toBe('1.5002568');
+        expect(entityStateDisplay(hass, stateObj, { format: 'mega9' })).toBe('0.001500257');
+        expect(entityStateDisplay(hass, stateObj, { format: 'milli0' })).toBe('1,500,257');
+    });
+
     it('leaves non-numeric values untouched when a format is configured', () => {
         const stateObj = { state: 'not-a-number', attributes: {} };
         expect(entityStateDisplay(hass, stateObj, { format: 'precision2' })).toBe('not-a-number');


### PR DESCRIPTION
## Summary
`invert` and `position` do arithmetic on the value before formatting (`value - value*2`, `100 - value`), which coerces a string state to a number before it reaches `formatNumber` — losing `formatNumber`'s "preserve the source string's decimal digits" handling and silently falling back to a hardcoded 2-decimal cap. Both now compute the source value's original decimal digit count and pass it through explicitly, so the formatted result keeps the same precision as an unformatted display of the same value.

`kilo` keeps its existing default (2-decimal cap) for backward compatibility, since that's documented behavior in the README, but now also accepts an optional digit suffix (`kilo0`-`kilo9`) for an exact user-requested precision — same pattern as the existing `precision<0-9>` format. Added matching `mega` (÷1,000,000) and `milli` (×1,000) formats.

Based on the approach in #344 (originally by @Jueff), which added `kilo<0-9>`/`mega<0-9>` but had a bug: it parsed the trailing digit with `parseInt(x, 5)` — `5` is the **radix** (base), not a default value, so digits 5-9 would silently produce `NaN` precision. Fixed to use base 10, matching the existing `precision<0-9>` code. Also added `milli`, and covered all three with tests including the digit-5-9 regression case.

None of `kilo`/`mega`/`milli`/`invert`/`position` change the displayed unit — documented that explicitly in the README, since it's easy to miss (the existing `kilo` doc example implied auto-relabeling that doesn't actually happen).

Fixes #304

## Test plan
- [x] Added regression tests for invert/position precision preservation
- [x] Added tests for kilo/mega/milli at default precision and with explicit digit suffixes, including digits 5-9 (the radix bug case)
- [x] `yarn build` (lint + 111 tests + webpack) passes clean
- [x] **Live-verified in a local HA testbed**: `invert`/`kilo`/`kilo3` against a real currency sensor, and `mega`/`mega5`/`milli`/`milli0` against dedicated test sensors — all match expected values exactly