### PR TITLE
Fix console spam on invalid currency codes; fix "undefined" attribute display

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -124,9 +124,14 @@ export const entityStateDisplay = (hass, stateObj, config) => {
     const modifiedStateObj = { ...stateObj, attributes: { ...stateObj.attributes, unit_of_measurement: unit } };
 
     if (config.attribute) {
-        return hasOfficialAttributeFormatter
-            ? hass.formatEntityAttributeValue(modifiedStateObj, config.attribute)
-            : `${isNaN(value) ? value : formatNumber(value, hass.locale)}${unit ? ` ${unit}` : ''}`;
+        if (hasOfficialAttributeFormatter) {
+            return hass.formatEntityAttributeValue(modifiedStateObj, config.attribute);
+        }
+        // A missing attribute is undefined, not a number or a real string - render an empty value
+        // rather than the literal string "undefined" (same class of bug as #225, in a code path
+        // that fix didn't cover since it only applies when a `format:` is configured).
+        const displayValue = value === undefined || value === null ? '' : isNaN(value) ? value : formatNumber(value, hass.locale);
+        return `${displayValue}${unit ? ` ${unit}` : ''}`;
     }
 
     return hasOfficialStateFormatter

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -71,6 +71,15 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { attribute: 'battery_level', unit: '%' })).toBe('42 %');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/225 and #352 - a missing
+    // attribute (no format: configured, no official formatter available) must render as an empty
+    // value, not the literal string "undefined".
+    it('renders a missing attribute as empty, not "undefined", with no format configured', () => {
+        const stateObj = { state: 'on', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { attribute: 'battery_level' })).toBe('');
+        expect(entityStateDisplay(hass, stateObj, { attribute: 'battery_level', unit: '%' })).toBe(' %');
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/335 -
     // brightness format converts 0-255 to a 0-100 percentage.
     it('applies the brightness format', () => {

--- a/src/lib/compute_state_display.js
+++ b/src/lib/compute_state_display.js
@@ -17,7 +17,14 @@ export const computeStateDisplay = (localize, stateObj, locale, entities, state)
 
     // Entities with a `unit_of_measurement` or `state_class` are numeric values and should use `formatNumber`
     if (isNumericState(stateObj)) {
-        if (stateObj.attributes.device_class === 'monetary') {
+        // Some monetary sensors use a non-ISO-4217 unit (e.g. "c/kWh" for cents per kilowatt-hour)
+        // that Intl.NumberFormat rejects as an invalid currency code. Only attempt currency
+        // formatting for a unit that actually looks like one - otherwise every render would throw,
+        // get caught, and spam the console for something that will never succeed (see #324).
+        if (
+            stateObj.attributes.device_class === 'monetary' &&
+            /^[A-Za-z]{3}$/.test(stateObj.attributes.unit_of_measurement)
+        ) {
             try {
                 return formatNumber(compareState, locale, {
                     style: 'currency',

--- a/src/lib/compute_state_display.test.js
+++ b/src/lib/compute_state_display.test.js
@@ -49,6 +49,22 @@ describe('computeStateDisplay', () => {
         expect(computeStateDisplay(localize, stateObj, locale)).toBe('$10.50');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/324 -
+    // a monetary sensor with a non-ISO-4217 unit (e.g. "c/kWh") must not attempt currency
+    // formatting at all, since Intl.NumberFormat always rejects it - that used to throw on every
+    // render (caught, but spamming the console) before falling back to the plain number + unit.
+    it('does not attempt currency formatting for a non-currency unit, and does not log an error', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const stateObj = {
+            entity_id: 'sensor.price',
+            state: '5.2',
+            attributes: { unit_of_measurement: 'c/kWh', device_class: 'monetary', state_class: 'measurement' },
+        };
+        expect(computeStateDisplay(localize, stateObj, locale)).toBe('5.2 c/kWh');
+        expect(consoleError).not.toHaveBeenCalled();
+        consoleError.mockRestore();
+    });
+
     it('formats counter/number/input_number domains without a unit', () => {
         const stateObj = { entity_id: 'counter.errands', state: '3', attributes: {} };
         expect(computeStateDisplay(localize, stateObj, locale)).toBe('3');


### PR DESCRIPTION
## Summary
Two small, related display bugs found while investigating #307/#352:

**#324** — `computeStateDisplay` attempted currency formatting for any `monetary` device_class sensor regardless of its unit, even when the unit isn't a valid ISO 4217 currency code (e.g. `c/kWh` for cents per kilowatt-hour). `Intl.NumberFormat` always rejects that, so every render threw, got caught, and logged the error — spamming the browser console for something that could never succeed. Now skips the currency attempt entirely when the unit doesn't look like a 3-letter currency code; display output (number + raw unit) is unchanged.

Traced this carefully before touching anything: confirmed with a throwaway test that the existing try/catch already prevented an actual crash (display already fell back gracefully to `5.2 c/kWh`) — the only real bug was the console noise from the internal retry-and-rethrow, not broken rendering.

Fixes #324

**Attribute-`undefined` gap** — `entityStateDisplay`'s attribute-display fallback (used when `hass.formatEntityAttributeValue` isn't available, i.e. older HA) rendered a missing attribute as the literal string `"undefined"` — same class of bug as #225, in a code path that fix didn't cover since it only applied when a `format:` was configured. Missing attributes now render as an empty value instead.

## Test plan
- [x] Added a test asserting `console.error` is not called for a monetary sensor with an invalid unit
- [x] Added a test for the missing-attribute-without-format case
- [x] `yarn build` (lint + 113 tests + webpack) passes clean
- [x] **Live-verified in a local HA testbed**: confirmed no console noise on a synthetic `c/kWh` monetary sensor after hard-refresh; confirmed the older-HA fallback path change doesn't affect modern HA's own `formatEntityAttributeValue` behavior (which already handles missing attributes gracefully with a localized "Unknown")