### PR TITLE
Fall back to time_format when HA's editor migrates format away (#386)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hide
 import { style } from './styles';
 
 console.info(
-    '%c MULTIPLE-ENTITY-ROW %c 4.6.0 ',
+    `%c MULTIPLE-ENTITY-ROW %c 4.6.0 (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
     'color: cyan; background: black; font-weight: bold;',
     'color: darkblue; background: white; font-weight: bold;'
 );
@@ -35,7 +35,16 @@ class MultipleEntityRow extends LitElement {
         this.entityIds = getEntityIds(config);
         this.onRowClick = this.clickHandler(config.entity, config.tap_action);
 
-        this.config = { ...config, name: config.name === false ? ' ' : config.name };
+        // HA 2026.7+'s entities-card row editor silently renames a row's `format` key to
+        // `time_format` on save, even for a custom row type with entirely different `format`
+        // semantics (see #386). That migration only touches the top-level row config, not our
+        // own nested `entities`/`secondary_info` config, so this fallback only needs to happen
+        // here. Prefer `format` if somehow both are present (e.g. a value hand-edited back in).
+        this.config = {
+            ...config,
+            name: config.name === false ? ' ' : config.name,
+            format: config.format ?? config.time_format,
+        };
     }
 
     shouldUpdate(changedProps) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -52,6 +52,20 @@ describe('multiple-entity-row', () => {
         expect(el.config.name).toBe(' ');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/386 - HA 2026.7+'s
+    // entities-card row editor silently renames a custom row's `format` key to `time_format` on
+    // save. Fall back to `time_format` when `format` itself isn't set, so a row edited through
+    // HA's own UI editor keeps working.
+    it('falls back to time_format when format was migrated away by HA', () => {
+        el.setConfig({ entity: 'sensor.main', time_format: 'precision2' });
+        expect(el.config.format).toBe('precision2');
+    });
+
+    it('prefers format over time_format if both are somehow present', () => {
+        el.setConfig({ entity: 'sensor.main', format: 'precision1', time_format: 'precision2' });
+        expect(el.config.format).toBe('precision1');
+    });
+
     it('renders no row content before hass and config are both set', async () => {
         await flushRender(el);
         expect(el.shadowRoot.innerHTML).not.toContain('hui-generic-entity-row');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,18 @@
 const webpack = require('webpack');
 const path = require('path');
+const { execSync } = require('child_process');
+
+// Baked into the console banner so a running instance can be identified as a specific build -
+// e.g. to tell a stale cached bundle apart from a freshly rebuilt one during local/HA testbed
+// development. Not meaningful for build reproducibility (a rebuild of the same commit produces
+// different bytes), which is fine here: the built file isn't a tracked/diffed artifact.
+const buildTime = new Date().toISOString();
+let buildCommit = 'unknown';
+try {
+    buildCommit = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (_err) {
+    // Not in a git checkout (e.g. a downloaded source tarball) - leave as 'unknown'.
+}
 
 module.exports = {
     mode: 'production',
@@ -25,6 +38,8 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),
+            'process.env.BUILD_TIME': JSON.stringify(buildTime),
+            'process.env.BUILD_COMMIT': JSON.stringify(buildCommit),
         }),
     ],
 };


### PR DESCRIPTION
## Summary
HA 2026.7+'s entities-card row editor silently renames a row's `format` key to `time_format` on save — even for a custom row type like this one, where `format` means something entirely different (this card's own number/precision formatting, not HA's timestamp-format concept). This happens purely within HA's own frontend before our config is ever read, so it can't be prevented from our side. Confirmed via live reproduction: editing a `multiple-entity-row` card through HA's visual editor (not YAML) and saving rewrites `format: precision2` to `time_format: precision2`.

The fix is defensive: `setConfig` now falls back to `config.time_format` when `config.format` isn't set, so a row edited through HA's UI editor keeps working regardless of which key survives the migration. Confirmed via the reporter that sub-entities aren't affected by HA's migration (it only touches the top-level row config), so this fallback only needs to happen once, at the main row's `setConfig`.

Also adds a build timestamp + short git commit SHA to the console banner — came up directly while trying to verify this fix in a local HA testbed, where stale client-side caching (likely a service worker) made it hard to tell whether a "reload" had actually picked up the new build. Not meaningful for build reproducibility (intentionally — the built file isn't a tracked/diffed artifact in this repo), but makes "which build is actually running" answerable at a glance in the browser console.

Fixes #386

## Test plan
- [x] Added tests for the time_format fallback (including "format wins if both are somehow present")
- [x] `yarn build` (lint + 115 tests + webpack) passes clean
- [x] **Live-verified in a local HA testbed**: reproduced the exact migration via HA's own visual editor, then confirmed a card configured with only `time_format: precision2` renders identically to `format: precision2`