### PR TITLE
Fix per-entity tap/hold/double-tap action handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,8 @@
     "confirm": true,
     "console": true,
     "customElements": true,
-    "Intl": true
+    "Intl": true,
+    "setTimeout": true,
+    "clearTimeout": true
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,19 @@ import { css, html, LitElement } from 'lit';
 import { handleClick } from 'custom-card-helpers';
 
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
+import { createGestureHandlers } from './lib/gesture_handler';
 import { checkEntity, entityName, entityStateDisplay, entityStyles } from './entity';
 import { getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
 import { style } from './styles';
+
+// hui-generic-entity-row attaches its own tap/hold/double-tap detection to the outer row
+// element unconditionally (see the catchInteraction comment in render() below) via mousedown/
+// click/touchstart/touchend/touchcancel/contextmenu listeners - a disjoint event set from the
+// pointerdown/pointerup/pointercancel we use for our own per-entity detection, so stopPropagation
+// on our own pointer events doesn't touch it. Stopping propagation of that exact event set at each
+// entity's own element keeps it from ever reaching the row's listener, so only our per-entity
+// dispatch fires (see #338, #202, #188, #251).
+const stopBubble = (event) => event.stopPropagation();
 
 console.info(
     `%c MULTIPLE-ENTITY-ROW %c ${process.env.PACKAGE_VERSION} (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
@@ -33,7 +43,10 @@ class MultipleEntityRow extends LitElement {
         }
 
         this.entityIds = getEntityIds(config);
-        this.onRowClick = this.clickHandler(config.entity, config.tap_action);
+        // Cached tap/hold/double-tap gesture state per rendered entity (see getGestureHandlers) -
+        // reset whenever config changes, since a config change can add/remove/reorder entities or
+        // their action configs.
+        this._actionHandlers = new Map();
 
         // HA 2026.7+'s entities-card row editor silently renames a row's `format` key to
         // `time_format` on save, even for a custom row type with entirely different `format`
@@ -77,14 +90,21 @@ class MultipleEntityRow extends LitElement {
         if (!this._hass || !this.config) return html``;
         if (!this.stateObj) return this.renderWarning();
 
+        // catchInteraction: true tells hui-generic-entity-row not to attach its own tap/hold/
+        // double-tap gesture detection to our slotted content. That detection is otherwise bound
+        // to the whole slot and dispatches using only the row-level config (this.config), with no
+        // awareness of which of our own rendered entities was actually interacted with - every
+        // sub-entity click also double-fired the main entity's own action config. Each of our
+        // entities gets its own tap/hold/double-tap handling in renderMainEntity/renderEntity
+        // instead, correctly scoped to its own action config (see #338, #202).
         return html`<hui-generic-entity-row
             .hass="${this._hass}"
             .config="${this.config}"
             .secondaryText="${this.renderSecondaryInfo()}"
-            .catchInteraction=${false}
+            .catchInteraction=${true}
         >
             <div class="${this.config.column ? 'entities-column' : 'entities-row'}">
-                ${this.entities.map((entity) => this.renderEntity(entity.stateObj, entity))}${this.renderMainEntity()}
+                ${this.entities.map((entity, index) => this.renderEntity(entity.stateObj, entity, index))}${this.renderMainEntity()}
             </div>
         </hui-generic-entity-row>`;
     }
@@ -108,13 +128,26 @@ class MultipleEntityRow extends LitElement {
         if (this.config.show_state === false) {
             return null;
         }
-        return html`<div class="state entity" style="${entityStyles(this.config)}" @click="${this.onRowClick}">
+        const gesture = this.getGestureHandlers('main', this.config.entity, this.config);
+        return html`<div
+            class="state entity"
+            style="${entityStyles(this.config)}"
+            @pointerdown="${gesture?.onDown}"
+            @pointerup="${gesture?.onUp}"
+            @pointercancel="${gesture?.onCancel}"
+            @mousedown="${stopBubble}"
+            @click="${stopBubble}"
+            @touchstart="${stopBubble}"
+            @touchend="${stopBubble}"
+            @touchcancel="${stopBubble}"
+            @contextmenu="${stopBubble}"
+        >
             ${this.config.state_header && html`<span>${this.config.state_header}</span>`}
             <div>${this.renderValue(this.stateObj, this.config)}</div>
         </div>`;
     }
 
-    renderEntity(stateObj, config) {
+    renderEntity(stateObj, config, index) {
         if (!stateObj || hideIf(stateObj, config)) {
             if (config.default) {
                 return html`<div class="entity" style="${entityStyles(config)}">
@@ -124,8 +157,20 @@ class MultipleEntityRow extends LitElement {
             }
             return null;
         }
-        const onClick = this.clickHandler(stateObj.entity_id, config.tap_action);
-        return html`<div class="entity" style="${entityStyles(config)}" @click="${onClick}">
+        const gesture = this.getGestureHandlers(`sub-${index}`, stateObj.entity_id, config);
+        return html`<div
+            class="entity"
+            style="${entityStyles(config)}"
+            @pointerdown="${gesture?.onDown}"
+            @pointerup="${gesture?.onUp}"
+            @pointercancel="${gesture?.onCancel}"
+            @mousedown="${stopBubble}"
+            @click="${stopBubble}"
+            @touchstart="${stopBubble}"
+            @touchend="${stopBubble}"
+            @touchcancel="${stopBubble}"
+            @contextmenu="${stopBubble}"
+        >
             <span>${entityName(stateObj, config)}</span>
             <div>${config.icon ? this.renderIcon(stateObj, config) : this.renderValue(stateObj, config)}</div>
         </div>`;
@@ -176,8 +221,41 @@ class MultipleEntityRow extends LitElement {
         </hui-warning>`;
     }
 
-    clickHandler(entity, actionConfig) {
-        return () => handleClick(this, this._hass, { entity, tap_action: actionConfig }, false, false);
+    // Tap/hold/double-tap gesture handlers for one rendered entity (the main entity, or one of
+    // this.entities by index), cached by key so an in-progress hold or double-tap window survives
+    // a re-render triggered by an unrelated state update mid-gesture (see setConfig). Toggle-mode
+    // entities render <ha-entity-toggle>, which handles its own tap directly - not wiring our own
+    // gesture handling on top avoids the two conflicting over the same interaction (see #265,
+    // which is about that toggle/action interaction specifically and is out of scope here).
+    getGestureHandlers(key, entity, config) {
+        if (config.toggle === true) {
+            return null;
+        }
+        if (!this._actionHandlers.has(key)) {
+            this._actionHandlers.set(
+                key,
+                createGestureHandlers(
+                    (hold, dblClick) => this.dispatchAction(entity, config, hold, dblClick),
+                    !!config.double_tap_action
+                )
+            );
+        }
+        return this._actionHandlers.get(key);
+    }
+
+    dispatchAction(entity, config, hold, dblClick) {
+        handleClick(
+            this,
+            this._hass,
+            {
+                entity,
+                tap_action: config.tap_action,
+                hold_action: config.hold_action,
+                double_tap_action: config.double_tap_action,
+            },
+            hold,
+            dblClick
+        );
     }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { handleClick } = vi.hoisted(() => ({ handleClick: vi.fn() }));
+vi.mock('custom-card-helpers', () => ({ handleClick }));
+
 import './index';
 
 const flushRender = async (el) => {
@@ -18,6 +22,7 @@ describe('multiple-entity-row', () => {
     let el;
 
     beforeEach(() => {
+        handleClick.mockClear();
         el = document.createElement('multiple-entity-row');
         document.body.appendChild(el);
     });
@@ -102,5 +107,85 @@ describe('multiple-entity-row', () => {
         el.hass = buildHass({ 'sensor.main': sharedState });
         const changedProps = new Map([['_hass', el._hass]]);
         expect(el.shouldUpdate(changedProps)).toBe(false);
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/338 and
+    // https://github.com/benct/lovelace-multiple-entity-row/issues/202 - tap/hold/double-tap must
+    // be handled per rendered entity, scoped to that entity's own action config, not just the main
+    // row's. See https://github.com/benct/lovelace-multiple-entity-row/issues/188 and
+    // https://github.com/benct/lovelace-multiple-entity-row/issues/251 - previously, every click
+    // anywhere in the row (including on a sub-entity) also bubbled into hui-generic-entity-row's
+    // own row-level action handling, which only ever knew about the main entity's config.
+    describe('gesture handling', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            el.setConfig({
+                entity: 'sensor.main',
+                tap_action: { action: 'toggle' },
+                entities: [{ entity: 'sensor.a', tap_action: { action: 'more-info', entity: 'sensor.a' } }],
+            });
+            el.hass = buildHass({
+                'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                'sensor.a': { entity_id: 'sensor.a', state: 'off', attributes: {} },
+            });
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('gives the main entity and a sub-entity independently cached gesture handlers', () => {
+            const main = el.getGestureHandlers('main', 'sensor.main', el.config);
+            const sub = el.getGestureHandlers('sub-0', 'sensor.a', el.config.entities[0]);
+            expect(main).not.toBe(sub);
+            // Same key + same render pass returns the same cached handlers, not a fresh set -
+            // this is what lets an in-progress hold/double-tap survive an unrelated re-render.
+            expect(el.getGestureHandlers('main', 'sensor.main', el.config)).toBe(main);
+        });
+
+        it('dispatches using only that entity\'s own action config, not the main row\'s', () => {
+            const sub = el.getGestureHandlers('sub-0', 'sensor.a', el.config.entities[0]);
+            sub.onDown();
+            sub.onUp();
+            expect(handleClick).toHaveBeenCalledExactlyOnceWith(
+                el,
+                el._hass,
+                {
+                    entity: 'sensor.a',
+                    tap_action: { action: 'more-info', entity: 'sensor.a' },
+                    hold_action: undefined,
+                    double_tap_action: undefined,
+                },
+                false,
+                false
+            );
+        });
+
+        it('dispatches a hold to hold_action for a sub-entity', () => {
+            const subConfig = { entity: 'sensor.a', tap_action: { action: 'toggle' }, hold_action: { action: 'more-info' } };
+            const sub = el.getGestureHandlers('sub-0', 'sensor.a', subConfig);
+            sub.onDown();
+            vi.advanceTimersByTime(500);
+            sub.onUp();
+            expect(handleClick).toHaveBeenCalledExactlyOnceWith(el, el._hass, expect.objectContaining({ entity: 'sensor.a' }), true, false);
+        });
+
+        it('does not attach gesture handlers for a toggle-mode entity', () => {
+            expect(el.getGestureHandlers('sub-0', 'sensor.a', { entity: 'sensor.a', toggle: true })).toBeNull();
+        });
+
+        // hui-generic-entity-row binds its own mousedown/click/touchstart/touchend/touchcancel/
+        // contextmenu listeners to the whole row regardless of catchInteraction (see #338) - if a
+        // sub-entity's click bubbled up to it, it would double-dispatch using the main row's config.
+        it('stops native click and mousedown events from bubbling past a sub-entity', async () => {
+            await flushRender(el);
+            const bubbled = vi.fn();
+            el.shadowRoot.addEventListener('click', bubbled);
+            el.shadowRoot.addEventListener('mousedown', bubbled);
+            const subDiv = el.shadowRoot.querySelector('.entity:not(.state)');
+            subDiv.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+            subDiv.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+            expect(bubbled).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/lib/gesture_handler.js
+++ b/src/lib/gesture_handler.js
@@ -1,0 +1,55 @@
+// Detects tap/hold/double-tap gestures from pointer events and dispatches the resolved gesture
+// via the given callback. custom-card-helpers only dispatches a *given* gesture (handleClick takes
+// hold/dblClick booleans) - it doesn't detect one, and HA's own internal <action-handler> element
+// isn't exposed for third-party use - so this reimplements that detection directly.
+//
+// Kept framework-free (no DOM/Lit dependency) so gesture timing can be unit tested with fake
+// timers, independent of rendering.
+
+export const HOLD_TIME_MS = 500;
+export const DOUBLE_TAP_WINDOW_MS = 250;
+
+// dispatch(hold, dblClick) is called once per resolved gesture. hasDoubleTapAction should be true
+// only when a double_tap_action is actually configured - otherwise a plain tap dispatches
+// immediately instead of waiting out the double-tap window for a second tap that will never come.
+export const createGestureHandlers = (dispatch, hasDoubleTapAction) => {
+    let holdTimer;
+    let held = false;
+    let pendingTapTimer;
+
+    const onDown = () => {
+        held = false;
+        holdTimer = setTimeout(() => {
+            held = true;
+        }, HOLD_TIME_MS);
+    };
+
+    const onCancel = () => {
+        clearTimeout(holdTimer);
+    };
+
+    const onUp = () => {
+        clearTimeout(holdTimer);
+        if (held) {
+            held = false;
+            dispatch(true, false);
+            return;
+        }
+        if (!hasDoubleTapAction) {
+            dispatch(false, false);
+            return;
+        }
+        if (pendingTapTimer) {
+            clearTimeout(pendingTapTimer);
+            pendingTapTimer = undefined;
+            dispatch(false, true);
+        } else {
+            pendingTapTimer = setTimeout(() => {
+                pendingTapTimer = undefined;
+                dispatch(false, false);
+            }, DOUBLE_TAP_WINDOW_MS);
+        }
+    };
+
+    return { onDown, onUp, onCancel };
+};

--- a/src/lib/gesture_handler.test.js
+++ b/src/lib/gesture_handler.test.js
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGestureHandlers, DOUBLE_TAP_WINDOW_MS, HOLD_TIME_MS } from './gesture_handler';
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('createGestureHandlers', () => {
+    it('dispatches a tap immediately when no double-tap action is configured', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        onDown();
+        onUp();
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, false);
+    });
+
+    it('dispatches a tap after the double-tap window elapses when no second tap follows', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        onDown();
+        onUp();
+        expect(dispatch).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(DOUBLE_TAP_WINDOW_MS);
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, false);
+    });
+
+    it('dispatches a double-tap when a second tap arrives within the window', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        onDown();
+        onUp();
+        vi.advanceTimersByTime(DOUBLE_TAP_WINDOW_MS / 2);
+        onDown();
+        onUp();
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, true);
+    });
+
+    it('dispatches a hold when the pointer is held past the hold threshold', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        onDown();
+        vi.advanceTimersByTime(HOLD_TIME_MS);
+        onUp();
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(true, false);
+    });
+
+    it('does not dispatch a hold if released before the hold threshold', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        onDown();
+        vi.advanceTimersByTime(HOLD_TIME_MS - 50);
+        onUp();
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, false);
+    });
+
+    it('does not dispatch anything on cancel, and does not leave a stale hold pending', () => {
+        const dispatch = vi.fn();
+        const { onDown, onCancel } = createGestureHandlers(dispatch, false);
+        onDown();
+        onCancel();
+        vi.advanceTimersByTime(HOLD_TIME_MS + DOUBLE_TAP_WINDOW_MS);
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('treats a hold on the second tap of what could have been a double-tap as a hold', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        onDown();
+        onUp();
+        vi.advanceTimersByTime(DOUBLE_TAP_WINDOW_MS / 2);
+        onDown();
+        vi.advanceTimersByTime(HOLD_TIME_MS);
+        onUp();
+        // The pending single-tap from the first press fires once its own window elapses,
+        // independent of the second press's hold - both are legitimate, distinct gestures here.
+        vi.runAllTimers();
+        expect(dispatch).toHaveBeenCalledWith(true, false);
+    });
+});


### PR DESCRIPTION
## Summary
`hui-generic-entity-row` attaches its own row-level tap/hold/double-tap
detection regardless of `catchInteraction`, always dispatching against
the main entity's config — so any tap on a sub-entity also fired the
main entity's action. This adds a reusable per-entity gesture handler
and stops those row-level listeners' events from bubbling out of each
entity's own element, so actions always resolve against the entity
that was actually interacted with.

Fixes #338, #202, #188, #251.

## Test plan
- [x] `yarn build` (lint + 127 tests + webpack) passes
- [x] Verified live in a local HA instance: tap/hold on both the main
      entity and sub-entities resolve to the correct entity's own
      action config, with and without a row-level `tap_action` set