### PR TITLE
Add hide_if entity/attribute references

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,26 @@ The `hide_if` option can be used to hide an entity if its state or attribute val
 It can be used directly with a string, number or boolean value (i.e. `hide_if: 'off'`), as a list with several values,
 or as an object with one or more of the options listed below.
 
-| Name    | Type     | Description                                                     |
-| ------- | -------- | --------------------------------------------------------------- |
-| above   | number   | Hidden if entity _number_ value is above the specified value    |
-| below   | number   | Hidden if entity _number_ value is below the specified value    |
-| value   | list/any | Hidden if value matches specified value or any value in a list  |
+| Name      | Type     | Description                                                     |
+| --------- | -------- | --------------------------------------------------------------- |
+| above     | number   | Hidden if entity _number_ value is above the specified value    |
+| below     | number   | Hidden if entity _number_ value is below the specified value    |
+| value     | list/any | Hidden if value matches specified value or any value in a list  |
+| entity    | string   | Evaluate the criteria against this entity instead of its own    |
+| attribute | string   | Evaluate the criteria against this attribute's value            |
+
+For example, only show the alarm exit-state sensor while the alarm is armed:
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: switch.dsc_armed_away
+  toggle: true
+  entities:
+    - entity: sensor.dsc_exit_state
+      hide_if:
+        entity: switch.dsc_armed_away
+        value: 'off'
+```
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class MultipleEntityRow extends LitElement {
         if (
             !this.config.secondary_info ||
             hasGenericSecondaryInfo(this.config.secondary_info) ||
-            hideIf(this.info, this.config.secondary_info)
+            hideIf(this.info, this.config.secondary_info, this._hass)
         ) {
             return null;
         }
@@ -148,7 +148,7 @@ class MultipleEntityRow extends LitElement {
     }
 
     renderEntity(stateObj, config, index) {
-        if (!stateObj || hideIf(stateObj, config)) {
+        if (!stateObj || hideIf(stateObj, config, this._hass)) {
             if (config.default) {
                 return html`<div class="entity" style="${entityStyles(config)}">
                     <span>${config.name}</span>

--- a/src/util.js
+++ b/src/util.js
@@ -11,7 +11,7 @@ export const hideUnavailable = (stateObj, config) =>
             ![LAST_CHANGED, LAST_UPDATED].includes(config.attribute) &&
             stateObj.attributes[config.attribute] === undefined));
 
-export const hideIf = (stateObj, config) => {
+export const hideIf = (stateObj, config, hass) => {
     if (hideUnavailable(stateObj, config)) {
         return true;
     }
@@ -19,7 +19,17 @@ export const hideIf = (stateObj, config) => {
         return false;
     }
 
-    const value = config.attribute ? stateObj.attributes[config.attribute] : stateObj.state;
+    let value;
+    if (isObject(config.hide_if) && (config.hide_if.entity || config.hide_if.attribute)) {
+        // Evaluate against another entity and/or attribute instead of the displayed value (see
+        // #280). A missing referenced entity yields undefined, so no criteria match and the
+        // entity stays visible - deliberately not falling back to the entity's own state, which
+        // would silently hide/show on the wrong value.
+        const sourceObj = config.hide_if.entity ? hass?.states[config.hide_if.entity] : stateObj;
+        value = config.hide_if.attribute ? sourceObj?.attributes[config.hide_if.attribute] : sourceObj?.state;
+    } else {
+        value = config.attribute ? stateObj.attributes[config.attribute] : stateObj.state;
+    }
     let hideValues = [];
 
     if (isObject(config.hide_if)) {
@@ -40,9 +50,15 @@ export const hideIf = (stateObj, config) => {
 
 export const hasGenericSecondaryInfo = (config) => typeof config === 'string' && SECONDARY_INFO_VALUES.includes(config);
 
+// hide_if.entity ids must be tracked too, or hasConfigOrEntitiesChanged would skip re-rendering
+// when only the referenced entity's state changes and the row would never hide/unhide.
 export const getEntityIds = (config) =>
-    [config.entity, config.secondary_info?.entity]
-        .concat(config.entities?.map((entity) => (typeof entity === 'string' ? entity : entity.entity)))
+    [config.entity, config.secondary_info?.entity, config.secondary_info?.hide_if?.entity]
+        .concat(
+            config.entities?.flatMap((entity) =>
+                typeof entity === 'string' ? entity : [entity.entity, entity.hide_if?.entity]
+            )
+        )
         .filter((entity) => entity);
 
 // HA installs stub formatEntityName/formatEntityState/formatEntityAttributeValue functions on

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -87,6 +87,42 @@ describe('hideIf', () => {
         expect(hideIf({ state: '15' }, { hide_if: { above: 10 } })).toBe(true);
         expect(hideIf({ state: '10' }, { hide_if: { below: 10, above: 10 } })).toBe(false);
     });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/pull/280 - hide_if.entity
+    // evaluates the criteria against another entity's state instead of the entity's own.
+    describe('with hide_if.entity/attribute', () => {
+        const hass = {
+            states: {
+                'switch.armed': { state: 'off', attributes: { mode: 'home' } },
+            },
+        };
+
+        it('checks the referenced entity state instead of its own', () => {
+            expect(hideIf({ state: 'on' }, { hide_if: { entity: 'switch.armed', value: 'off' } }, hass)).toBe(true);
+            expect(hideIf({ state: 'off' }, { hide_if: { entity: 'switch.armed', value: 'on' } }, hass)).toBe(false);
+        });
+
+        it('supports thresholds against the referenced entity', () => {
+            const numHass = { states: { 'sensor.level': { state: '5', attributes: {} } } };
+            expect(hideIf({ state: 'on' }, { hide_if: { entity: 'sensor.level', below: 10 } }, numHass)).toBe(true);
+            expect(hideIf({ state: 'on' }, { hide_if: { entity: 'sensor.level', above: 10 } }, numHass)).toBe(false);
+        });
+
+        it('checks the referenced entity attribute when hide_if.attribute is set', () => {
+            expect(
+                hideIf({ state: 'on' }, { hide_if: { entity: 'switch.armed', attribute: 'mode', value: 'home' } }, hass)
+            ).toBe(true);
+        });
+
+        it('checks its own attribute when only hide_if.attribute is set', () => {
+            const stateObj = { state: 'on', attributes: { mode: 'away' } };
+            expect(hideIf(stateObj, { hide_if: { attribute: 'mode', value: 'away' } }, hass)).toBe(true);
+        });
+
+        it('stays visible when the referenced entity does not exist', () => {
+            expect(hideIf({ state: 'off' }, { hide_if: { entity: 'switch.missing', value: 'off' } }, hass)).toBe(false);
+        });
+    });
 });
 
 describe('hasGenericSecondaryInfo', () => {
@@ -112,6 +148,17 @@ describe('getEntityIds', () => {
 
     it('filters out missing entries', () => {
         expect(getEntityIds({ entities: [] })).toEqual([]);
+    });
+
+    // Referenced hide_if entities must be watched too, or the row would never re-render (and so
+    // never hide/unhide) when only the referenced entity changes.
+    it('collects hide_if.entity references', () => {
+        const config = {
+            entity: 'sensor.main',
+            secondary_info: { entity: 'sensor.secondary', hide_if: { entity: 'switch.a', value: 'off' } },
+            entities: [{ entity: 'sensor.b', hide_if: { entity: 'switch.b', value: 'off' } }],
+        };
+        expect(getEntityIds(config)).toEqual(['sensor.main', 'sensor.secondary', 'switch.a', 'sensor.b', 'switch.b']);
     });
 });
 


### PR DESCRIPTION
## Summary
`hide_if` can now evaluate its criteria against another entity's state or attribute instead of the entity's own value, via `hide_if.entity` / `hide_if.attribute`.

Reimplements #280 (thanks @akomelj) on the current codebase, with two additions: referenced entities are added to the watched-entity list so the row re-renders when only they change, and a missing referenced entity leaves the row visible rather than falling back to the entity's own state.

```yaml
entities:
  - entity: sensor.dsc_exit_state
    hide_if:
      entity: switch.dsc_armed_away
      value: 'off'
```

## Test plan
- [x] `yarn build` (lint + 133 tests + webpack) passes; 6 new unit tests
- [x] Verified live in a local HA instance: sub-entity hides/shows as the referenced switch toggles