### PR TITLE
Fix uncaught RangeError for an incomplete precision/kilo/mega/milli format

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -23,15 +23,33 @@ export const computeEntity = (entityId) => entityId.substr(entityId.indexOf('.')
 const decimalDigits = (value) => (typeof value === 'string' && value.includes('.') ? value.split('.')[1].length : undefined);
 
 // Shared implementation for the kilo/mega/milli formats: divides by the given factor, and applies
-// either the default 2-decimal cap (bare `kilo`/`mega`/`milli`, unchanged from prior behavior) or
-// an explicit user-requested precision (`kilo3`, `mega1`, `milli0`, ...).
-const scaledFormat = (value, divisor, digitSuffix, locale) => {
-    if (digitSuffix === '') {
+// either the default 2-decimal cap (bare `kilo`/`mega`/`milli`, digits === undefined) or an
+// explicit user-requested precision (`kilo3`, `mega1`, `milli0`, ...).
+const scaledFormat = (value, divisor, digits, locale) => {
+    if (digits === undefined) {
         return formatNumber(value / divisor, locale, { maximumFractionDigits: 2 });
     }
-    const precision = parseInt(digitSuffix, 10);
+    const precision = parseInt(digits, 10);
     return formatNumber(value / divisor, locale, { minimumFractionDigits: precision, maximumFractionDigits: precision });
 };
+
+// precision<N>/kilo<N>/mega<N>/milli<N> parse a trailing digit off the format string. `kilo`,
+// `mega` and `milli` alone are valid (their own documented 2-decimal default); `precision` alone
+// is not, since it has no bare-word default. Anything else with one of these prefixes - e.g.
+// "kiloX", or mid-typed in a config editor before the digit is added - doesn't match this pattern
+// at all. Rather than crash (Intl.NumberFormat throws for a NaN minimumFractionDigits) or guess at
+// a fallback precision, that's treated as an incomplete format for this render, falling through to
+// the same official-entity-formatter path used when no format is configured at all (see #387).
+const DIGIT_SUFFIX_PREFIXES = ['precision', 'kilo', 'mega', 'milli'];
+const DIGIT_SUFFIX_FORMAT = /^(precision|kilo|mega|milli)(\d+)?$/;
+
+// The match, or null if config.format isn't a complete precision/kilo/mega/milli format.
+const matchDigitSuffixFormat = (format) => {
+    const match = DIGIT_SUFFIX_FORMAT.exec(format);
+    return match && (match[1] !== 'precision' || match[2] !== undefined) ? match : null;
+};
+const isIncompleteDigitSuffixFormat = (format) =>
+    DIGIT_SUFFIX_PREFIXES.some((prefix) => format?.startsWith(prefix)) && !matchDigitSuffixFormat(format);
 
 export const entityName = (stateObj, config) => {
     if (config.name === false) return null;
@@ -63,7 +81,7 @@ export const entityStateDisplay = (hass, stateObj, config) => {
             ? config.unit
             : config.unit || stateObj.attributes.unit_of_measurement;
 
-    if (config.format) {
+    if (config.format && !isIncompleteDigitSuffixFormat(config.format)) {
         // A missing attribute (e.g. brightness/color_temp on a light that's off) is undefined,
         // not a number - treat it as 0 rather than letting it flow through to the final template
         // literal below as the literal string "undefined" (see #225). A value that's some other
@@ -87,18 +105,17 @@ export const entityStateDisplay = (hass, stateObj, config) => {
         } else if (config.format === 'duration-h') {
             value = secondsToDuration(value * 3600) ?? '0';
             unit = undefined;
-        } else if (config.format.startsWith('precision')) {
-            const precision = parseInt(config.format.slice(-1), 10);
-            value = formatNumber(parseFloat(value), hass.locale, {
-                minimumFractionDigits: precision,
-                maximumFractionDigits: precision,
-            });
-        } else if (config.format.startsWith('kilo')) {
-            value = scaledFormat(value, 1000, config.format.slice(4), hass.locale);
-        } else if (config.format.startsWith('mega')) {
-            value = scaledFormat(value, 1000000, config.format.slice(4), hass.locale);
-        } else if (config.format.startsWith('milli')) {
-            value = scaledFormat(value, 1 / 1000, config.format.slice(5), hass.locale);
+        } else if (matchDigitSuffixFormat(config.format)) {
+            const [, type, digits] = matchDigitSuffixFormat(config.format);
+            if (type === 'precision') {
+                const precision = parseInt(digits, 10);
+                value = formatNumber(parseFloat(value), hass.locale, {
+                    minimumFractionDigits: precision,
+                    maximumFractionDigits: precision,
+                });
+            } else {
+                value = scaledFormat(value, { kilo: 1000, mega: 1000000, milli: 1 / 1000 }[type], digits, hass.locale);
+            }
         } else if (config.format === 'invert') {
             const precision = decimalDigits(value);
             value = formatNumber(

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -107,6 +107,15 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { format: 'precision2' })).toBe('3.14');
     });
 
+    // A bare "precision" with no trailing digit (e.g. typed incrementally in a config editor
+    // before the digit is added) must not crash with an uncaught RangeError, regardless of
+    // whether the official formatter is available (see the officialHass block below for the
+    // precise fallback-value assertion).
+    it('does not throw for a bare "precision" format with no digit', () => {
+        const stateObj = { entity_id: 'sensor.temp', state: '3.14159', attributes: {} };
+        expect(() => entityStateDisplay(hass, stateObj, { format: 'precision' })).not.toThrow();
+    });
+
     it('applies the invert format', () => {
         const stateObj = { state: '5', attributes: {} };
         expect(entityStateDisplay(hass, stateObj, { format: 'invert' })).toBe('-5');
@@ -158,6 +167,15 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { format: 'milli0' })).toBe('1,500,257');
     });
 
+    // Same class of crash as the bare "precision" case above - an invalid or missing digit
+    // suffix (e.g. mid-typed in a config editor) must fall back to the default, not crash.
+    it('does not throw for kilo/mega/milli with an invalid digit suffix', () => {
+        const stateObj = { entity_id: 'sensor.temp', state: '1500.256789', attributes: {} };
+        expect(() => entityStateDisplay(hass, stateObj, { format: 'kiloX' })).not.toThrow();
+        expect(() => entityStateDisplay(hass, stateObj, { format: 'megaX' })).not.toThrow();
+        expect(() => entityStateDisplay(hass, stateObj, { format: 'milliX' })).not.toThrow();
+    });
+
     it('leaves non-numeric values untouched when a format is configured', () => {
         const stateObj = { state: 'not-a-number', attributes: {} };
         expect(entityStateDisplay(hass, stateObj, { format: 'precision2' })).toBe('not-a-number');
@@ -202,6 +220,16 @@ describe('entityStateDisplay', () => {
         it('delegates main state display to formatEntityState', () => {
             const stateObj = { entity_id: 'sensor.temp', state: '21', attributes: {} };
             expect(entityStateDisplay(officialHass, stateObj, {})).toBe('official-state:21');
+        });
+
+        // See #387 - a bare "precision" (no default of its own) or an invalid digit suffix
+        // (e.g. mid-typed in a config editor) is treated as no format configured for this
+        // render, falling through to the official per-entity formatter rather than crashing or
+        // guessing at a fallback precision of our own.
+        it('falls through to the official formatter for an incomplete digit-suffix format', () => {
+            const stateObj = { entity_id: 'sensor.temp', state: '21', attributes: {} };
+            expect(entityStateDisplay(officialHass, stateObj, { format: 'precision' })).toBe('official-state:21');
+            expect(entityStateDisplay(officialHass, stateObj, { format: 'kiloX' })).toBe('official-state:21');
         });
 
         it('still applies a custom format instead of the official formatters', () => {


### PR DESCRIPTION
## Summary
Typing `format: precision` (or `kilo`/`mega`/`milli`) without its digit suffix mid-edit threw an uncaught `RangeError: minimumFractionDigits value is out of range` in the config editor. An incomplete digit-suffix format is now treated as "no format configured", falling through to HA's own per-entity formatter. Consolidates the four separate `startsWith`/`slice` dispatch branches into one regex reused for validity-checking and dispatch.

Fixes #387.

## Test plan
- [x] `yarn build` (lint + tests + webpack) passes
- [x] Verified live: typing `format: precision` character-by-character in the editor no longer throws