### PR TITLE
Dispatch actions via HA's native hass-action event

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "author": "benct <ben@tomlin.no>",
   "license": "MIT",
   "dependencies": {
-    "custom-card-helpers": "2.0.0",
     "lit": "^3.3.3",
     "memoize-one": "^6.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,16 @@
 import { css, html, LitElement } from 'lit';
-import { handleClick } from 'custom-card-helpers';
 
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
 import { checkEntity, entityName, entityStateDisplay, entityStyles } from './entity';
-import { getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
+import {
+    fireEvent,
+    getEntityIds,
+    hasConfigOrEntitiesChanged,
+    hasGenericSecondaryInfo,
+    hideIf,
+    isObject,
+} from './util';
 import { style } from './styles';
 
 // hui-generic-entity-row attaches its own tap/hold/double-tap detection to the outer row
@@ -234,28 +240,38 @@ class MultipleEntityRow extends LitElement {
         if (!this._actionHandlers.has(key)) {
             this._actionHandlers.set(
                 key,
-                createGestureHandlers(
-                    (hold, dblClick) => this.dispatchAction(entity, config, hold, dblClick),
-                    !!config.double_tap_action
-                )
+                createGestureHandlers((hold, dblClick) => this.dispatchAction(entity, config, hold, dblClick), {
+                    hasHold: !!config.hold_action,
+                    hasDoubleTap: !!config.double_tap_action,
+                })
             );
         }
         return this._actionHandlers.get(key);
     }
 
+    // Dispatch by firing HA's own hass-action event rather than performing the action ourselves
+    // (the old custom-card-helpers handleClick call). Letting HA core execute it keeps native
+    // confirmation dialogs and security-domain restrictions (lock/cover) in the loop, and
+    // supports newer action types (perform-action, assist) for free. Approach adopted from the
+    // duczz/ha-multiple-entity-row fork.
     dispatchAction(entity, config, hold, dblClick) {
-        handleClick(
-            this,
-            this._hass,
-            {
-                entity,
-                tap_action: config.tap_action,
-                hold_action: config.hold_action,
-                double_tap_action: config.double_tap_action,
+        const actionConfig = dblClick
+            ? config.double_tap_action
+            : hold
+              ? config.hold_action
+              : config.tap_action ?? { action: 'more-info' };
+        if (!actionConfig || actionConfig.action === 'none') {
+            return;
+        }
+        const actionType = dblClick ? 'double_tap' : hold ? 'hold' : 'tap';
+        fireEvent(this, 'hass-action', {
+            config: {
+                // actionConfig.entity overrides the more-info target (see #188)
+                entity: actionConfig.entity || entity,
+                [`${actionType}_action`]: actionConfig,
             },
-            hold,
-            dblClick
-        );
+            action: actionType,
+        });
     }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,9 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { handleClick } = vi.hoisted(() => ({ handleClick: vi.fn() }));
-vi.mock('custom-card-helpers', () => ({ handleClick }));
-
 import './index';
 
 const flushRender = async (el) => {
@@ -22,7 +19,6 @@ describe('multiple-entity-row', () => {
     let el;
 
     beforeEach(() => {
-        handleClick.mockClear();
         el = document.createElement('multiple-entity-row');
         document.body.appendChild(el);
     });
@@ -117,8 +113,12 @@ describe('multiple-entity-row', () => {
     // anywhere in the row (including on a sub-entity) also bubbled into hui-generic-entity-row's
     // own row-level action handling, which only ever knew about the main entity's config.
     describe('gesture handling', () => {
+        let actions;
+
         beforeEach(() => {
             vi.useFakeTimers();
+            actions = [];
+            el.addEventListener('hass-action', (ev) => actions.push(ev.detail));
             el.setConfig({
                 entity: 'sensor.main',
                 tap_action: { action: 'toggle' },
@@ -147,27 +147,45 @@ describe('multiple-entity-row', () => {
             const sub = el.getGestureHandlers('sub-0', 'sensor.a', el.config.entities[0]);
             sub.onDown();
             sub.onUp();
-            expect(handleClick).toHaveBeenCalledExactlyOnceWith(
-                el,
-                el._hass,
+            expect(actions).toEqual([
                 {
-                    entity: 'sensor.a',
-                    tap_action: { action: 'more-info', entity: 'sensor.a' },
-                    hold_action: undefined,
-                    double_tap_action: undefined,
+                    config: { entity: 'sensor.a', tap_action: { action: 'more-info', entity: 'sensor.a' } },
+                    action: 'tap',
                 },
-                false,
-                false
-            );
+            ]);
         });
 
+        // Handlers are cached per key until the next setConfig, so these tests reset the config
+        // (clearing the cache) rather than passing an ad-hoc config for an already-cached key.
         it('dispatches a hold to hold_action for a sub-entity', () => {
             const subConfig = { entity: 'sensor.a', tap_action: { action: 'toggle' }, hold_action: { action: 'more-info' } };
+            el.setConfig({ entity: 'sensor.main', entities: [subConfig] });
             const sub = el.getGestureHandlers('sub-0', 'sensor.a', subConfig);
             sub.onDown();
             vi.advanceTimersByTime(500);
             sub.onUp();
-            expect(handleClick).toHaveBeenCalledExactlyOnceWith(el, el._hass, expect.objectContaining({ entity: 'sensor.a' }), true, false);
+            expect(actions).toEqual([
+                { config: { entity: 'sensor.a', hold_action: { action: 'more-info' } }, action: 'hold' },
+            ]);
+        });
+
+        it('defaults a tap with no tap_action to more-info', () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a' }] });
+            const sub = el.getGestureHandlers('sub-0', 'sensor.a', { entity: 'sensor.a' });
+            sub.onDown();
+            sub.onUp();
+            expect(actions).toEqual([
+                { config: { entity: 'sensor.a', tap_action: { action: 'more-info' } }, action: 'tap' },
+            ]);
+        });
+
+        it('does not dispatch when the action is none', () => {
+            const subConfig = { entity: 'sensor.a', tap_action: { action: 'none' } };
+            el.setConfig({ entity: 'sensor.main', entities: [subConfig] });
+            const sub = el.getGestureHandlers('sub-0', 'sensor.a', subConfig);
+            sub.onDown();
+            sub.onUp();
+            expect(actions).toEqual([]);
         });
 
         it('does not attach gesture handlers for a toggle-mode entity', () => {

--- a/src/lib/gesture_handler.js
+++ b/src/lib/gesture_handler.js
@@ -1,7 +1,6 @@
 // Detects tap/hold/double-tap gestures from pointer events and dispatches the resolved gesture
-// via the given callback. custom-card-helpers only dispatches a *given* gesture (handleClick takes
-// hold/dblClick booleans) - it doesn't detect one, and HA's own internal <action-handler> element
-// isn't exposed for third-party use - so this reimplements that detection directly.
+// via the given callback. HA's own internal <action-handler> element isn't exposed for
+// third-party use, so this reimplements that detection directly.
 //
 // Kept framework-free (no DOM/Lit dependency) so gesture timing can be unit tested with fake
 // timers, independent of rendering.
@@ -9,19 +8,23 @@
 export const HOLD_TIME_MS = 500;
 export const DOUBLE_TAP_WINDOW_MS = 250;
 
-// dispatch(hold, dblClick) is called once per resolved gesture. hasDoubleTapAction should be true
-// only when a double_tap_action is actually configured - otherwise a plain tap dispatches
-// immediately instead of waiting out the double-tap window for a second tap that will never come.
-export const createGestureHandlers = (dispatch, hasDoubleTapAction) => {
+// dispatch(hold, dblClick) is called once per resolved gesture. hasHold/hasDoubleTap should be
+// true only when the corresponding action is actually configured - like HA's native rows, a
+// long-press without a hold_action resolves as a plain tap, and without a double_tap_action a
+// tap dispatches immediately instead of waiting out the double-tap window for a second tap that
+// will never come.
+export const createGestureHandlers = (dispatch, { hasHold, hasDoubleTap }) => {
     let holdTimer;
     let held = false;
     let pendingTapTimer;
 
     const onDown = () => {
         held = false;
-        holdTimer = setTimeout(() => {
-            held = true;
-        }, HOLD_TIME_MS);
+        if (hasHold) {
+            holdTimer = setTimeout(() => {
+                held = true;
+            }, HOLD_TIME_MS);
+        }
     };
 
     const onCancel = () => {
@@ -35,7 +38,7 @@ export const createGestureHandlers = (dispatch, hasDoubleTapAction) => {
             dispatch(true, false);
             return;
         }
-        if (!hasDoubleTapAction) {
+        if (!hasDoubleTap) {
             dispatch(false, false);
             return;
         }

--- a/src/lib/gesture_handler.test.js
+++ b/src/lib/gesture_handler.test.js
@@ -11,7 +11,7 @@ afterEach(() => {
 describe('createGestureHandlers', () => {
     it('dispatches a tap immediately when no double-tap action is configured', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: false });
         onDown();
         onUp();
         expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, false);
@@ -19,7 +19,7 @@ describe('createGestureHandlers', () => {
 
     it('dispatches a tap after the double-tap window elapses when no second tap follows', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: true });
         onDown();
         onUp();
         expect(dispatch).not.toHaveBeenCalled();
@@ -29,7 +29,7 @@ describe('createGestureHandlers', () => {
 
     it('dispatches a double-tap when a second tap arrives within the window', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: true });
         onDown();
         onUp();
         vi.advanceTimersByTime(DOUBLE_TAP_WINDOW_MS / 2);
@@ -40,16 +40,26 @@ describe('createGestureHandlers', () => {
 
     it('dispatches a hold when the pointer is held past the hold threshold', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: false });
         onDown();
         vi.advanceTimersByTime(HOLD_TIME_MS);
         onUp();
         expect(dispatch).toHaveBeenCalledExactlyOnceWith(true, false);
     });
 
+    // Matches HA's native rows: without a hold_action, a long-press is just a slow tap.
+    it('resolves a long-press as a tap when no hold action is configured', () => {
+        const dispatch = vi.fn();
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: false, hasDoubleTap: false });
+        onDown();
+        vi.advanceTimersByTime(HOLD_TIME_MS * 2);
+        onUp();
+        expect(dispatch).toHaveBeenCalledExactlyOnceWith(false, false);
+    });
+
     it('does not dispatch a hold if released before the hold threshold', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, false);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: false });
         onDown();
         vi.advanceTimersByTime(HOLD_TIME_MS - 50);
         onUp();
@@ -58,7 +68,7 @@ describe('createGestureHandlers', () => {
 
     it('does not dispatch anything on cancel, and does not leave a stale hold pending', () => {
         const dispatch = vi.fn();
-        const { onDown, onCancel } = createGestureHandlers(dispatch, false);
+        const { onDown, onCancel } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: false });
         onDown();
         onCancel();
         vi.advanceTimersByTime(HOLD_TIME_MS + DOUBLE_TAP_WINDOW_MS);
@@ -67,7 +77,7 @@ describe('createGestureHandlers', () => {
 
     it('treats a hold on the second tap of what could have been a double-tap as a hold', () => {
         const dispatch = vi.fn();
-        const { onDown, onUp } = createGestureHandlers(dispatch, true);
+        const { onDown, onUp } = createGestureHandlers(dispatch, { hasHold: true, hasDoubleTap: true });
         onDown();
         onUp();
         vi.advanceTimersByTime(DOUBLE_TAP_WINDOW_MS / 2);

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,13 @@ import { LAST_CHANGED, LAST_UPDATED, SECONDARY_INFO_VALUES, UNAVAILABLE_STATES }
 
 export const isObject = (obj) => typeof obj === 'object' && !Array.isArray(obj) && !!obj;
 
+// bubbles + composed so the event crosses our shadow root up to HA's root-level listener.
+export const fireEvent = (node, type, detail) => {
+    const event = new Event(type, { bubbles: true, composed: true });
+    event.detail = detail;
+    node.dispatchEvent(event);
+};
+
 export const isUnavailable = (stateObj) => !stateObj || UNAVAILABLE_STATES.includes(stateObj.state);
 
 export const hideUnavailable = (stateObj, config) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,30 +1042,6 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
   integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
 
-"@formatjs/fast-memoize@3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz#fca16a7d60f89df48f506f130f58223d7d81c2a2"
-  integrity sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==
-
-"@formatjs/icu-messageformat-parser@3.5.12":
-  version "3.5.12"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.12.tgz#120384e7767fc3741a740c700463daff7ccbf048"
-  integrity sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==
-  dependencies:
-    "@formatjs/icu-skeleton-parser" "2.1.10"
-
-"@formatjs/icu-skeleton-parser@2.1.10":
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz#a72859339c68ce29d595d27c481115a50b8b6527"
-  integrity sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==
-
-"@formatjs/intl-utils@^3.8.4":
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-3.8.4.tgz#291baac91001db428fc3275c515a3e40fbe95945"
-  integrity sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==
-  dependencies:
-    emojis-list "^3.0.0"
-
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
@@ -1808,16 +1784,6 @@ css-tree@^3.0.0, css-tree@^3.2.1:
     mdn-data "2.27.1"
     source-map-js "^1.2.1"
 
-custom-card-helpers@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/custom-card-helpers/-/custom-card-helpers-2.0.0.tgz#fb3a718cd6fed5c0933068b7533f2e80d4173b3b"
-  integrity sha512-TrWc9lybHFrbdZFv1kzKaiFY/vYon08N1k4iUS8EDLIJObWP0K+B1lU0XCAG6Q/3euAyM5nn1QjUSvcnCYpNtg==
-  dependencies:
-    "@formatjs/intl-utils" "^3.8.4"
-    home-assistant-js-websocket "^9.6.0"
-    intl-messageformat "^11.1.2"
-    superstruct "^2.0.2"
-
 data-urls@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-7.0.0.tgz#6dce8b63226a1ecfdd907ce18a8ccfb1eee506d3"
@@ -1854,11 +1820,6 @@ electron-to-chromium@^1.5.376:
   version "1.5.381"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz#037549001adc80e04834ede96dc52a1fbf6c9fde"
   integrity sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==
-
-emojis-list@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
-  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 enhanced-resolve@^5.22.2:
   version "5.24.1"
@@ -2230,11 +2191,6 @@ hasown@^2.0.3:
   dependencies:
     function-bind "^1.1.2"
 
-home-assistant-js-websocket@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-9.6.0.tgz#46d1743276419e1bd78ba2bb51c6d5d0c0835f90"
-  integrity sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==
-
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
@@ -2290,14 +2246,6 @@ interpret@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
-
-intl-messageformat@^11.1.2:
-  version "11.2.9"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-11.2.9.tgz#ae866df5c72a0b6693f0936c2b9a154c9c73a2d2"
-  integrity sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==
-  dependencies:
-    "@formatjs/fast-memoize" "3.1.6"
-    "@formatjs/icu-messageformat-parser" "3.5.12"
 
 is-core-module@^2.16.1:
   version "2.16.2"
@@ -3021,11 +2969,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-superstruct@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-2.0.2.tgz#3f6d32fbdc11c357deff127d591a39b996300c54"
-  integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
 supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
## Summary
Actions now dispatch by firing HA's `hass-action` event and letting HA core execute them, instead of calling `custom-card-helpers`' `handleClick` (dependency removed — it's unmaintained and this was its only use). This restores native confirmation dialogs and security-domain restrictions for lock/cover actions, and supports `perform-action` / `assist`.

Behavior detail: a long-press without a `hold_action` now resolves as a plain tap, matching HA's native rows (previously it opened more-info).

Approach adopted from the [duczz/ha-multiple-entity-row](https://github.com/duczz/ha-multiple-entity-row) fork — thanks @duczz.

## Test plan
- [x] `yarn build` (lint + 139 tests + webpack) passes
- [x] Verified live in a local HA instance: confirmation dialog appears and cancels correctly, per-entity tap/hold/double-tap resolve to the right entity, `action: none` dispatches nothing, long-press without `hold_action` acts as a tap