### PR TITLE
Backport runtime features from the duczz fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ This card produces an `entity-row` and must therefore be configured as an entity
 | name              | string/bool   | `friendly_name`                     | Override entity friendly name                    |
 | unit              | string/bool   | `unit_of_measurement`               | Override entity unit of measurement              |
 | icon              | string        | `icon`                              | Override entity icon or image                    |
+| icon_color        | string        |                                     | CSS color for the entity icon                    |
+| state_icon        | object        |                                     | Map of state value → icon override               |
 | image             | string        |                                     | Show an image instead of icon                    |
 | toggle            | bool          | `false`                             | Display a toggle (if supported) instead of state |
 | show_state        | bool          | `true`                              | Set to `false` to hide the main entity           |
 | state_header      | string        |                                     | Show header text above the main entity state     |
 | state_color       | bool          | `false`                             | Enable colored icon when entity is active        |
 | column            | bool          | `false`                             | Show entities in a column instead of a row       |
+| default           | string        |                                     | Display this value when the state is hidden      |
+| hide_unavailable  | bool          | `false`                             | Hide the state value if unavailable              |
+| hide_if           | object/any    | _[Hiding](#hiding)_                 | Hide the state value if criteria match           |
 | styles            | object        |                                     | Add custom CSS styles to the state element       |
 | format            | string        | _[Formatting](#formatting)_         | Format main state/attribute value                |
 |                   |
@@ -79,6 +84,8 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | toggle            | bool        | `false`                     | Display a toggle if supported by domain                            |
 | icon              | string/bool | `false`                     | Display default or custom icon instead of state or attribute value |
 | state_color       | bool        | `false`                     | Enable colored icon when entity is active                          |
+| icon_color        | string      |                             | CSS color for the entity icon                                      |
+| state_icon        | object      |                             | Map of state value → icon override                                 |
 | default           | string      |                             | Display this value if the entity does not exist or is hidden       |
 | hide_unavailable  | bool        | `false`                     | Hide entity if it is unavailable or does not exist                 |
 | hide_if           | object/any  | _[Hiding](#hiding)_         | Hide entity if its value matches specified value or criteria       |
@@ -143,6 +150,7 @@ The `format` option supports the following values:
 | time                  | `timestamp` | Convert timestamp value to time                                  |
 | datetime              | `timestamp` | Convert timestamp value to date and time                         |
 | brightness            | `number`    | Convert brightness value to percentage                           |
+| percent               | `number`    | Multiply a fraction value by 100 and append `%` (`0.25` -> `25 %`) |
 | duration              | `number`    | Convert number of seconds to duration (`5:38:50`)                |
 | duration-m            | `number`    | Convert number of milliseconds to duration (`5:38:50`)           |
 | duration-h            | `number`    | Convert number of hours to duration (`5:38:50`)                  |
@@ -154,6 +162,10 @@ The `format` option supports the following values:
 | precision<0-9>        | `number`    | Set decimal precision of number value (`precision3` -> `18.123`) |
 | celsius_to_fahrenheit | `number`    | Converts a Celsius temperature to its Fahrenheit equivalent      |
 | fahrenheit_to_celsius | `number`    | Converts a Fahrenheit temperature to its Celsius equivalent      |
+| upper                 | `string`    | UPPERCASE the value                                              |
+| lower                 | `string`    | lowercase the value                                              |
+| capitalize            | `string`    | Capitalize the first letter of the value                         |
+| title                 | `string`    | Title Case Each Word Of The Value                                |
 
 `kilo`/`mega`/`milli` on their own default to a maximum of 2 decimal places. Suffix a digit (`kilo3`, `mega1`, `milli0`, ...) to request an exact decimal precision instead, the same way `precision<0-9>` does.
 
@@ -191,6 +203,25 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
       hide_if:
         entity: switch.dsc_armed_away
         value: 'off'
+```
+
+`hide_if` and `hide_unavailable` at the top level hide the main entity's state value (the row itself stays visible); `default` is shown in its place when set.
+
+### Icon styling
+
+`icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
+
+```yaml
+- entity: binary_sensor.front_door
+  type: custom:multiple-entity-row
+  icon_color: 'var(--accent-color)'
+  state_icon:
+    'on': mdi:door-open
+    'off': mdi:door-closed
+  entities:
+    - entity: binary_sensor.back_door
+      icon: true
+      icon_color: red
 ```
 
 ## Examples

--- a/src/entity.js
+++ b/src/entity.js
@@ -51,6 +51,36 @@ const matchDigitSuffixFormat = (format) => {
 const isIncompleteDigitSuffixFormat = (format) =>
     DIGIT_SUFFIX_PREFIXES.some((prefix) => format?.startsWith(prefix)) && !matchDigitSuffixFormat(format);
 
+// String-only transforms - operate on any value, including non-numeric text states (see #367).
+const STRING_FORMATS = ['upper', 'lower', 'capitalize', 'title'];
+const stringTransform = (format, value) => {
+    switch (format) {
+        case 'upper':
+            return value.toUpperCase();
+        case 'lower':
+            return value.toLowerCase();
+        case 'capitalize':
+            return value.charAt(0).toUpperCase() + value.slice(1);
+        case 'title':
+            // Split-and-capitalize rather than a \b\w or \p{L} regex: \b\w mishandles words
+            // starting with a non-ASCII letter ("über"), and \p{L} gets expanded by babel
+            // into a ~9KiB character class that bloats the bundle.
+            return value
+                .split(/(\s+)/)
+                .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+                .join('');
+    }
+};
+
+// Sets all three icon-color variables so the override is robust across HA versions; cascades
+// from the styled element down into nested state-badges (see #325).
+export const iconColorCss = (color) =>
+    color ? `--paper-item-icon-color: ${color}; --mdc-icon-color: ${color}; --state-icon-color: ${color};` : '';
+
+// The state_icon map's icon for the current state, or undefined (see #197).
+export const stateIcon = (stateObj, config) =>
+    isObject(config.state_icon) ? config.state_icon[stateObj.state] : undefined;
+
 export const entityName = (stateObj, config) => {
     if (config.name === false) return null;
     return (
@@ -83,16 +113,24 @@ export const entityStateDisplay = (hass, stateObj, config) => {
 
     if (config.format && !isIncompleteDigitSuffixFormat(config.format)) {
         // A missing attribute (e.g. brightness/color_temp on a light that's off) is undefined,
-        // not a number - treat it as 0 rather than letting it flow through to the final template
-        // literal below as the literal string "undefined" (see #225). A value that's some other
-        // non-numeric type (e.g. a genuine text attribute) is left untouched, same as before.
+        // not a number - treat it as 0 (empty for the string transforms) rather than letting it
+        // flow through to the final template literal below as the literal string "undefined"
+        // (see #225). A value that's some other non-numeric type (e.g. a genuine text attribute)
+        // is left untouched, same as before.
         if (value === undefined || value === null) {
-            value = 0;
+            value = STRING_FORMATS.includes(config.format) ? '' : 0;
+        }
+        if (STRING_FORMATS.includes(config.format)) {
+            return `${stringTransform(config.format, String(value))}${unit ? ` ${unit}` : ''}`;
         }
         if (isNaN(parseFloat(value)) || !isFinite(value)) {
             // do nothing if not a number
         } else if (config.format === 'brightness') {
             value = Math.round((value / 255) * 100);
+            unit = '%';
+        } else if (config.format === 'percent') {
+            // value × 100 → x % - for fraction-valued sensors (see #323)
+            value = formatNumber(value * 100, hass.locale, { maximumFractionDigits: 2 });
             unit = '%';
         } else if (config.format === 'duration') {
             // secondsToDuration returns null for a zero duration; fall back to '0'

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { checkEntity, computeEntity, entityName, entityStateDisplay, entityStyles } from './entity';
+import { checkEntity, computeEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
 import { NumberFormat } from './lib/constants';
 
 const hass = {
@@ -90,6 +90,31 @@ describe('entityStateDisplay', () => {
     it('applies the duration format', () => {
         const stateObj = { state: '90', attributes: {} };
         expect(entityStateDisplay(hass, stateObj, { format: 'duration' })).toBe('1:30');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/323
+    it('applies the percent format', () => {
+        const stateObj = { state: '0.253', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'percent' })).toBe('25.3 %');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/367
+    it('applies the string-transform formats', () => {
+        const stateObj = { state: 'partly cloudy', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'upper' })).toBe('PARTLY CLOUDY');
+        expect(entityStateDisplay(hass, stateObj, { format: 'lower' })).toBe('partly cloudy');
+        expect(entityStateDisplay(hass, stateObj, { format: 'capitalize' })).toBe('Partly cloudy');
+        expect(entityStateDisplay(hass, stateObj, { format: 'title' })).toBe('Partly Cloudy');
+    });
+
+    it('title-cases words starting with non-ASCII letters', () => {
+        const stateObj = { state: 'über den berg', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { format: 'title' })).toBe('Über Den Berg');
+    });
+
+    it('renders a missing attribute as empty for a string transform, not "undefined"', () => {
+        const stateObj = { state: 'on', attributes: {} };
+        expect(entityStateDisplay(hass, stateObj, { attribute: 'missing', format: 'upper' })).toBe('');
     });
 
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/240 -
@@ -247,5 +272,33 @@ describe('entityStyles', () => {
     it('returns an empty string when there are no styles', () => {
         expect(entityStyles({})).toBe('');
         expect(entityStyles(undefined)).toBe('');
+    });
+});
+
+// See https://github.com/benct/lovelace-multiple-entity-row/issues/325
+describe('iconColorCss', () => {
+    it('sets all icon-color variables for a configured color', () => {
+        expect(iconColorCss('red')).toBe(
+            '--paper-item-icon-color: red; --mdc-icon-color: red; --state-icon-color: red;'
+        );
+    });
+
+    it('returns an empty string when no color is configured', () => {
+        expect(iconColorCss(undefined)).toBe('');
+    });
+});
+
+// See https://github.com/benct/lovelace-multiple-entity-row/issues/197
+describe('stateIcon', () => {
+    const config = { state_icon: { on: 'mdi:door-open', off: 'mdi:door-closed' } };
+
+    it('returns the mapped icon for the current state', () => {
+        expect(stateIcon({ state: 'on' }, config)).toBe('mdi:door-open');
+        expect(stateIcon({ state: 'off' }, config)).toBe('mdi:door-closed');
+    });
+
+    it('returns undefined for an unmapped state or no state_icon config', () => {
+        expect(stateIcon({ state: 'unknown' }, config)).toBeUndefined();
+        expect(stateIcon({ state: 'on' }, {})).toBeUndefined();
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit';
 
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
-import { checkEntity, entityName, entityStateDisplay, entityStyles } from './entity';
+import { checkEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
 import {
     fireEvent,
     getEntityIds,
@@ -96,6 +96,11 @@ class MultipleEntityRow extends LitElement {
         if (!this._hass || !this.config) return html``;
         if (!this.stateObj) return this.renderWarning();
 
+        // A state_icon match overrides the main row's icon by injecting it into the config
+        // handed to hui-generic-entity-row, which owns the main icon rendering (see #197).
+        const mainStateIcon = stateIcon(this.stateObj, this.config);
+        const rowConfig = mainStateIcon ? { ...this.config, icon: mainStateIcon } : this.config;
+
         // catchInteraction: true tells hui-generic-entity-row not to attach its own tap/hold/
         // double-tap gesture detection to our slotted content. That detection is otherwise bound
         // to the whole slot and dispatches using only the row-level config (this.config), with no
@@ -104,8 +109,9 @@ class MultipleEntityRow extends LitElement {
         // entities gets its own tap/hold/double-tap handling in renderMainEntity/renderEntity
         // instead, correctly scoped to its own action config (see #338, #202).
         return html`<hui-generic-entity-row
+            style="${iconColorCss(this.config.icon_color)}"
             .hass="${this._hass}"
-            .config="${this.config}"
+            .config="${rowConfig}"
             .secondaryText="${this.renderSecondaryInfo()}"
             .catchInteraction=${true}
         >
@@ -132,6 +138,18 @@ class MultipleEntityRow extends LitElement {
 
     renderMainEntity() {
         if (this.config.show_state === false) {
+            return null;
+        }
+        // Top-level hide_if/hide_unavailable hide the main state slot, symmetrical to per-entity
+        // behavior - previously they were silently ignored on the main entity (see #227). The row
+        // itself (name, icon, sub-entities) stays visible.
+        if (hideIf(this.stateObj, this.config, this._hass)) {
+            if (this.config.default) {
+                return html`<div class="state entity" style="${entityStyles(this.config)}">
+                    ${this.config.state_header && html`<span>${this.config.state_header}</span>`}
+                    <div>${this.config.default}</div>
+                </div>`;
+            }
             return null;
         }
         const gesture = this.getGestureHandlers('main', this.config.entity, this.config);
@@ -178,7 +196,11 @@ class MultipleEntityRow extends LitElement {
             @contextmenu="${stopBubble}"
         >
             <span>${entityName(stateObj, config)}</span>
-            <div>${config.icon ? this.renderIcon(stateObj, config) : this.renderValue(stateObj, config)}</div>
+            <div>
+                ${config.icon || isObject(config.state_icon)
+                    ? this.renderIcon(stateObj, config)
+                    : this.renderValue(stateObj, config)}
+            </div>
         </div>`;
     }
 
@@ -212,11 +234,15 @@ class MultipleEntityRow extends LitElement {
     }
 
     renderIcon(stateObj, config) {
+        // Resolution order: state_icon[state] (see #197) → explicit icon → entity's own icon.
+        const overrideIcon =
+            stateIcon(stateObj, config) ?? (config.icon === true ? stateObj.attributes.icon || null : config.icon);
         return html`<state-badge
             class="icon-small"
+            style="${iconColorCss(config.icon_color)}"
             .hass=${this._hass}
             .stateObj="${stateObj}"
-            .overrideIcon="${config.icon === true ? stateObj.attributes.icon || null : config.icon}"
+            .overrideIcon="${overrideIcon}"
             .stateColor="${config.state_color}"
         ></state-badge>`;
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -97,6 +97,31 @@ describe('multiple-entity-row', () => {
         expect(el.entities[0].stateObj.entity_id).toBe('sensor.a');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/227 - top-level
+    // hide_if/hide_unavailable were silently ignored on the main entity.
+    describe('main-row hiding', () => {
+        it('hides the main state slot when top-level hide_if matches', async () => {
+            el.setConfig({ entity: 'sensor.main', hide_if: 'off' });
+            el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'off', attributes: {} } });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.state.entity')).toBeNull();
+        });
+
+        it('shows the main state slot when hide_if does not match', async () => {
+            el.setConfig({ entity: 'sensor.main', hide_if: 'off' });
+            el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.state.entity')).not.toBeNull();
+        });
+
+        it('renders the default value when the main state is hidden', async () => {
+            el.setConfig({ entity: 'sensor.main', hide_if: 'off', default: 'n/a' });
+            el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'off', attributes: {} } });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.state.entity').textContent).toContain('n/a');
+        });
+    });
+
     it('shouldUpdate returns false when neither config nor watched entities changed', () => {
         el.setConfig({ entity: 'sensor.main' });
         const sharedState = { entity_id: 'sensor.main', state: 'on', attributes: {} };

--- a/src/util.js
+++ b/src/util.js
@@ -60,7 +60,7 @@ export const hasGenericSecondaryInfo = (config) => typeof config === 'string' &&
 // hide_if.entity ids must be tracked too, or hasConfigOrEntitiesChanged would skip re-rendering
 // when only the referenced entity's state changes and the row would never hide/unhide.
 export const getEntityIds = (config) =>
-    [config.entity, config.secondary_info?.entity, config.secondary_info?.hide_if?.entity]
+    [config.entity, config.hide_if?.entity, config.secondary_info?.entity, config.secondary_info?.hide_if?.entity]
         .concat(
             config.entities?.flatMap((entity) =>
                 typeof entity === 'string' ? entity : [entity.entity, entity.hide_if?.entity]

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -155,10 +155,18 @@ describe('getEntityIds', () => {
     it('collects hide_if.entity references', () => {
         const config = {
             entity: 'sensor.main',
+            hide_if: { entity: 'switch.main', value: 'off' },
             secondary_info: { entity: 'sensor.secondary', hide_if: { entity: 'switch.a', value: 'off' } },
             entities: [{ entity: 'sensor.b', hide_if: { entity: 'switch.b', value: 'off' } }],
         };
-        expect(getEntityIds(config)).toEqual(['sensor.main', 'sensor.secondary', 'switch.a', 'sensor.b', 'switch.b']);
+        expect(getEntityIds(config)).toEqual([
+            'sensor.main',
+            'switch.main',
+            'sensor.secondary',
+            'switch.a',
+            'sensor.b',
+            'switch.b',
+        ]);
     });
 });
 


### PR DESCRIPTION
## Summary
Backports five runtime features from the actively-maintained [duczz/ha-multiple-entity-row](https://github.com/duczz/ha-multiple-entity-row) fork — thanks @duczz. Each closes an open issue here:

- **`percent` format** — value × 100 with `%` appended (#323)
- **`upper` / `lower` / `capitalize` / `title` string formats** (#367) — `title` handles non-ASCII first letters correctly, implemented without `\p{L}` (babel expands it to ~9KiB of character classes)
- **Top-level `hide_if` / `hide_unavailable`** now hide the main state slot, symmetrical to per-entity behavior, showing `default` in its place if set (#227)
- **`icon_color`** — any CSS color applied to entity icons via HA's icon-color variables, main row and sub-entities (#325)
- **`state_icon`** — map of state → icon override, takes precedence over `icon` (#197)

## Test plan
- [x] `yarn build` (lint + 150 tests + webpack) passes; 11 new unit/integration tests, all verified to fail without the feature code
- [x] Verified live in a local HA instance: state-driven icons and colors on main + sub-entities, main-state hiding with `default` fallback, and all new formats