### PR TITLE
Add visual config editor (TypeScript)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,9 +4,25 @@
     "plugin:prettier/recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 2020,
+    "ecmaVersion": 2021,
     "sourceType": "module"
   },
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint"],
+      "extends": ["plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+      "rules": {
+        "no-undef": "off",
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ],
   "globals": {
     "window": true,
     "document": true,
@@ -14,6 +30,7 @@
     "confirm": true,
     "console": true,
     "customElements": true,
+    "process": true,
     "Intl": true,
     "setTimeout": true,
     "clearTimeout": true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The above configuration can be managed in the Configuration -> Dashboards -> Res
 
 This card produces an `entity-row` and must therefore be configured as an entity in an [entities](https://www.home-assistant.io/lovelace/entities/) card.
 
+A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, digit-suffixed formats like `precision5`) are YAML-only.
+
 | Name              | Type          | Default                             | Description                                      |
 | ----------------- | ------------- | ----------------------------------- | ------------------------------------------------ |
 | type              | string        | **Required**                        | `custom:multiple-entity-row`                     |
@@ -415,10 +417,12 @@ entities:
 
 ```bash
 yarn install
-yarn build      # lint, run tests, then bundle multiple-entity-row.js
+yarn build      # lint + type-check, run tests, then bundle multiple-entity-row.js
 yarn test       # run the unit test suite
 yarn coverage   # run tests with a coverage report
 ```
+
+The codebase is migrating incrementally from JavaScript to TypeScript: `.ts` and `.js` coexist (`allowJs`), Babel strips types during bundling, and `tsc --noEmit` type-checks as part of `yarn lint`. New code should be TypeScript; existing modules migrate opportunistically when touched.
 
 To test changes against a real Home Assistant instance, a disposable local testbed is available via Docker:
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "@babel/core": "^7.22.1",
     "@babel/preset-env": "^7.22.4",
+    "@babel/preset-typescript": "^7.27.0",
+    "@typescript-eslint/eslint-plugin": "^8.62.1",
+    "@typescript-eslint/parser": "^8.62.1",
     "@vitest/coverage-v8": "^4.1.9",
     "babel-loader": "^9.1.2",
     "eslint": "^8.41.0",
@@ -29,12 +32,13 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jsdom": "^29.1.1",
     "prettier": "^2.8.8",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "webpack": "^5.84.1",
     "webpack-cli": "^5.1.1"
   },
   "scripts": {
-    "lint": "eslint src/**/*.js",
+    "lint": "eslint 'src/**/*.{js,ts}' && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",

--- a/src/editor.test.ts
+++ b/src/editor.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import './editor';
+import type { MultipleEntityRowEditor } from './editor';
+import type { MultipleEntityRowConfig } from './types';
+
+const buildHass = () => ({
+    states: {},
+    entities: {},
+    locale: { number_format: 'comma_decimal', language: 'en-US' },
+    localize: vi.fn((key: string) => key),
+    callService: vi.fn(),
+});
+
+describe('multiple-entity-row-editor', () => {
+    let el: MultipleEntityRowEditor;
+    let configs: MultipleEntityRowConfig[];
+
+    const setConfig = (config: Partial<MultipleEntityRowConfig>) => el.setConfig(config as MultipleEntityRowConfig);
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        configs = [];
+        el = document.createElement('multiple-entity-row-editor') as MultipleEntityRowEditor;
+        el.addEventListener('config-changed', (ev) => configs.push((ev as any).detail.config));
+        (el as any).hass = buildHass();
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        el.remove();
+    });
+
+    it('registers the editor custom element', () => {
+        expect(customElements.get('multiple-entity-row-editor')).toBeDefined();
+    });
+
+    it('clamps the selected tab when entities shrink below it', () => {
+        setConfig({ entity: 'sensor.main', entities: ['sensor.a', 'sensor.b'] });
+        (el as any)._selectedTab = 2;
+        setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+        expect((el as any)._selectedTab).toBe(1);
+    });
+
+    describe('main tab form', () => {
+        it('seeds show_state default ON and strips the redundant true on write-back', () => {
+            setConfig({ entity: 'sensor.main' });
+            expect((el as any)._mainFormData().show_state).toBe(true);
+
+            (el as any)._mainValueChanged({ detail: { value: { entity: 'sensor.main', show_state: true } } });
+            expect(configs).toHaveLength(1);
+            expect('show_state' in configs[0]).toBe(false);
+        });
+
+        it('round-trips unit: false through the text form as the string "false"', () => {
+            setConfig({ entity: 'sensor.main', unit: false });
+            expect((el as any)._mainFormData().unit).toBe('false');
+
+            (el as any)._mainValueChanged({ detail: { value: { entity: 'sensor.main', unit: 'false' } } });
+            expect(configs[0].unit).toBe(false);
+        });
+    });
+
+    describe('additional entities', () => {
+        it('adds an empty entity and selects its tab', () => {
+            setConfig({ entity: 'sensor.main' });
+            (el as any)._addEntity();
+            expect(configs[0].entities).toEqual([{}]);
+            expect((el as any)._selectedTab).toBe(1);
+        });
+
+        it('deletes an entity and drops the entities key when the last one goes', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+            (el as any)._deleteAdditional(0);
+            expect('entities' in configs[0]).toBe(false);
+        });
+
+        it('moves an entity and follows it with the selected tab', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a', 'sensor.b'] });
+            (el as any)._moveAdditional(0, 1);
+            expect(configs[0].entities).toEqual(['sensor.b', 'sensor.a']);
+            expect((el as any)._selectedTab).toBe(2);
+        });
+
+        it('normalizes a string entity to an object when its form changes', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+            (el as any)._additionalValueChanged({ detail: { value: { entity: 'sensor.a', name: 'A' } } }, 0);
+            expect(configs[0].entities).toEqual([{ entity: 'sensor.a', name: 'A' }]);
+        });
+    });
+
+    describe('clipboard', () => {
+        it('copies an entity and pastes it as a new one', () => {
+            setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', name: 'A' }] });
+            (el as any)._copyAdditional(0);
+            (el as any)._pasteEntity();
+            expect(configs[0].entities).toEqual([
+                { entity: 'sensor.a', name: 'A' },
+                { entity: 'sensor.a', name: 'A' },
+            ]);
+        });
+
+        it('copies main as a template with only per-entity-relevant fields', () => {
+            setConfig({
+                entity: 'sensor.main',
+                name: 'Main',
+                column: true,
+                show_state: false,
+                state_header: 'hdr',
+                icon_color: 'red',
+            });
+            (el as any)._copyMainAsTemplate();
+            (el as any)._pasteEntity();
+            expect(configs[0].entities).toEqual([{ entity: 'sensor.main', name: 'Main', icon_color: 'red' }]);
+        });
+
+        it('cut removes the source entity and fills the clipboard', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a', 'sensor.b'] });
+            (el as any)._cutAdditional(0);
+            const last = configs[configs.length - 1];
+            expect(last.entities).toEqual(['sensor.b']);
+            expect((el as any)._clipboardEntity).toEqual({ entity: 'sensor.a' });
+        });
+    });
+
+    describe('secondary info modes', () => {
+        it('detects the mode from the config shape', () => {
+            setConfig({ entity: 'sensor.main' });
+            expect((el as any)._secondaryInfoMode()).toBe('none');
+            setConfig({ entity: 'sensor.main', secondary_info: 'last-changed' });
+            expect((el as any)._secondaryInfoMode()).toBe('generic');
+            setConfig({ entity: 'sensor.main', secondary_info: 'hello' });
+            expect((el as any)._secondaryInfoMode()).toBe('text');
+            setConfig({ entity: 'sensor.main', secondary_info: { entity: 'sensor.a' } });
+            expect((el as any)._secondaryInfoMode()).toBe('entity');
+        });
+
+        it('switching mode seeds a sensible starting value', () => {
+            setConfig({ entity: 'sensor.main' });
+            (el as any)._secondaryModeChanged({ detail: { value: { mode: 'entity' } } });
+            expect(configs[0].secondary_info).toEqual({ entity: 'sensor.main' });
+
+            (el as any)._secondaryModeChanged({ detail: { value: { mode: 'generic' } } });
+            expect(configs[1].secondary_info).toBe('last-changed');
+        });
+
+        it('switching to none removes the key entirely', () => {
+            setConfig({ entity: 'sensor.main', secondary_info: 'hello' });
+            (el as any)._secondaryModeChanged({ detail: { value: { mode: 'none' } } });
+            expect('secondary_info' in configs[0]).toBe(false);
+        });
+    });
+
+    describe('state_icon rows', () => {
+        it('propagates only complete rows to the config', () => {
+            setConfig({ entity: 'sensor.main' });
+            (el as any)._setStateIconRows('main', [
+                ['on', 'mdi:door-open'],
+                ['off', ''], // incomplete draft - stays local
+            ]);
+            expect(configs[0].state_icon).toEqual({ on: 'mdi:door-open' });
+        });
+
+        it('drops the state_icon key when all rows are removed', () => {
+            setConfig({ entity: 'sensor.main', state_icon: { on: 'mdi:door-open' } });
+            (el as any)._setStateIconRows('main', []);
+            expect('state_icon' in configs[0]).toBe(false);
+        });
+
+        it('preserves an in-progress draft row across a setConfig round-trip', () => {
+            setConfig({ entity: 'sensor.main' });
+            (el as any)._setStateIconRows('main', [
+                ['on', 'mdi:door-open'],
+                ['off', ''],
+            ]);
+            // Simulate HA handing the (filtered) config back after config-changed.
+            setConfig({ entity: 'sensor.main', state_icon: { on: 'mdi:door-open' } });
+            expect((el as any)._stateIconRowsMain).toEqual([
+                ['on', 'mdi:door-open'],
+                ['off', ''],
+            ]);
+        });
+    });
+
+    describe('custom CSS block', () => {
+        it('parses key: value lines into the styles object', () => {
+            setConfig({ entity: 'sensor.main' });
+            (el as any)._mainStylesChanged({ detail: { value: 'width: 80px\ncolor: "red"\n# comment\nbad-line' } });
+            expect(configs[0].styles).toEqual({ width: '80px', color: 'red' });
+        });
+
+        it('removes the styles key when the block is emptied', () => {
+            setConfig({ entity: 'sensor.main', styles: { width: '80px' } });
+            (el as any)._mainStylesChanged({ detail: { value: '' } });
+            expect('styles' in configs[0]).toBe(false);
+        });
+
+        it('writes per-entity styles into that entity only', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+            (el as any)._additionalStylesChanged({ detail: { value: 'color: red' } }, 0);
+            expect(configs[0].entities).toEqual([{ entity: 'sensor.a', styles: { color: 'red' } }]);
+        });
+    });
+});

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,874 @@
+// Visual config editor, adapted from the duczz/ha-multiple-entity-row fork's editor.ts
+// (credit @duczz). Built on HA's native <ha-form> renderer with schemas in editor_schemas.ts.
+//
+// Written without Lit decorators: reactive properties are declared via static get properties()
+// (matching the rest of this codebase), with `declare` class fields for typing only - a real
+// class field would shadow Lit's generated accessors and silently break reactivity.
+
+import { css, html, LitElement, nothing, TemplateResult } from 'lit';
+import { keyed } from 'lit/directives/keyed.js';
+
+import { SECONDARY_INFO_VALUES } from './lib/constants';
+import { fireEvent, isObject } from './util';
+import { ADDITIONAL_TAB_SCHEMA, LABELS, MAIN_TAB_SCHEMA } from './editor_schemas';
+import { EntityConfig, HASS, MultipleEntityRowConfig } from './types';
+
+type SecondaryMode = 'none' | 'text' | 'generic' | 'entity';
+
+// Inlined @mdi/js path strings - not worth a dependency for five icons.
+const PATH_PLUS = 'M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z';
+const PATH_DELETE = 'M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z';
+const PATH_COPY =
+    'M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z';
+const PATH_CUT =
+    'M19,3L13,9L15,11L22,4V3M12,12.5A0.5,0.5 0 0,1 11.5,12A0.5,0.5 0 0,1 12,11.5A0.5,0.5 0 0,1 12.5,12A0.5,0.5 0 0,1 12,12.5M6,20A2,2 0 0,1 4,18C4,16.89 4.9,16 6,16A2,2 0 0,1 8,18C8,19.11 7.1,20 6,20M6,8A2,2 0 0,1 4,6C4,4.89 4.9,4 6,4A2,2 0 0,1 8,6C8,7.11 7.1,8 6,8M9.64,7.64C9.87,7.14 10,6.59 10,6A4,4 0 0,0 6,2A4,4 0 0,0 2,6A4,4 0 0,0 6,10C6.59,10 7.14,9.87 7.64,9.64L10,12L7.64,14.36C7.14,14.13 6.59,14 6,14A4,4 0 0,0 2,18A4,4 0 0,0 6,22A4,4 0 0,0 10,18C10,17.41 9.87,16.86 9.64,16.36L12,14L19,21H22V20L9.64,7.64Z';
+const PATH_PASTE =
+    'M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z';
+const PATH_MOVE_BEFORE = 'M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z';
+const PATH_MOVE_AFTER = 'M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z';
+
+const SECONDARY_MODE_SCHEMA = [
+    {
+        name: 'mode',
+        selector: {
+            select: {
+                mode: 'dropdown',
+                options: [
+                    { value: 'none', label: 'None' },
+                    { value: 'text', label: 'Custom text' },
+                    { value: 'generic', label: 'HA built-in token' },
+                    { value: 'entity', label: 'Entity-based' },
+                ],
+            },
+        },
+    },
+];
+
+const GENERIC_TOKEN_SCHEMA = [
+    {
+        name: 'token',
+        selector: {
+            select: { mode: 'dropdown', options: SECONDARY_INFO_VALUES.map((v: string) => ({ value: v, label: v })) },
+        },
+    },
+];
+
+const TEXT_SCHEMA = [{ name: 'text', selector: { text: { multiline: true } } }];
+
+// Per-row schema for the state_icon row UI - a grid with a text input for the state name and an
+// icon-selector for the icon. Routed via ha-form so it uses HA's standard form renderer.
+const STATE_ICON_ROW_SCHEMA = [
+    {
+        type: 'grid',
+        schema: [
+            { name: 'state', selector: { text: {} } },
+            { name: 'icon', selector: { icon: {} } },
+        ],
+    },
+];
+
+const STATE_ICON_ROW_LABEL = (item: { name: string }): string =>
+    item.name === 'state' ? 'State' : item.name === 'icon' ? 'Icon' : item.name;
+
+/** Object {color: 'red', ...} → YAML-style "color: red\n..." text for the code editor. */
+const stringifyStyles = (styles: unknown): string => {
+    if (!styles || typeof styles !== 'object' || Array.isArray(styles)) return '';
+    return Object.entries(styles as Record<string, any>)
+        .filter(([, v]) => v != null)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+};
+
+/** Parse YAML-style "key: value" lines back into a styles object. Lax: ignores empty lines,
+ * `#` comments, and malformed lines (they stay visible in the editor until fixed). */
+const parseStylesText = (text: string): Record<string, string> => {
+    const result: Record<string, string> = {};
+    if (!text) return result;
+    for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const colonIdx = trimmed.indexOf(':');
+        if (colonIdx < 1) continue;
+        const key = trimmed.slice(0, colonIdx).trim();
+        let value = trimmed.slice(colonIdx + 1).trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        }
+        if (key && value) result[key] = value;
+    }
+    return result;
+};
+
+/** `unit: false` (hide the unit) is a boolean in YAML but must round-trip through ha-form's text
+ * selector - map it to/from the literal string 'false'. Side benefit: typing "false" into the
+ * unit field sets the boolean form from the editor. */
+const unitToForm = <T extends Record<string, any>>(config: T): T =>
+    config.unit === false ? { ...config, unit: 'false' } : config;
+
+const unitFromForm = <T extends Record<string, any>>(config: T): T =>
+    config.unit === 'false' ? { ...config, unit: false } : config;
+
+// Our own clipboard slot. Deliberately NOT HA's `dashboardCardClipboard` - that one holds
+// Lovelace card configs and is consumed by <hui-card-picker>; pasting an entity sub-config
+// there would surface garbage in HA's card picker.
+const CLIPBOARD_KEY = 'multipleEntityRowClipboard';
+
+// Subset of top-level config keys that semantically represent the "main entity slot" - used when
+// copying Main into the clipboard so the pasted entry behaves naturally as an additional entity
+// (no row-wide options like image / show_state / state_header / column).
+const MAIN_COPYABLE_FIELDS: (keyof MultipleEntityRowConfig)[] = [
+    'entity',
+    'name',
+    'attribute',
+    'unit',
+    'icon',
+    'icon_color',
+    'state_icon',
+    'state_color',
+    'toggle',
+    'hide_unavailable',
+    'format',
+    'tap_action',
+    'styles',
+];
+
+type StateIconRows = [string, string][];
+
+export class MultipleEntityRowEditor extends LitElement {
+    declare hass?: HASS;
+    declare _config?: MultipleEntityRowConfig;
+    declare _selectedTab: number;
+    declare _entitiesExpanded: boolean;
+    declare _clipboardEntity?: EntityConfig;
+    declare _stateIconRowsMain: StateIconRows;
+    declare _stateIconRowsAdditional: Map<number, StateIconRows>;
+
+    // Per-position stable keys for the entities tab list - lit needs these to swap tab contents
+    // wholesale on reorder instead of mutating sibling tab contents in place.
+    private _keys: Map<number, string> = new Map();
+
+    static get properties() {
+        return {
+            // Reactive: HA re-assigns hass on every state tick; without this the entity pickers
+            // inside ha-form would keep the hass they got on the last config change and go stale.
+            hass: { attribute: false },
+            _config: { state: true },
+            // Tab 0 = Main (writes top-level config keys); 1+ = config.entities[tab - 1].
+            _selectedTab: { state: true },
+            _entitiesExpanded: { state: true },
+            _clipboardEntity: { state: true },
+            _stateIconRowsMain: { state: true },
+            _stateIconRowsAdditional: { state: true },
+        };
+    }
+
+    constructor() {
+        super();
+        this._selectedTab = 0;
+        this._entitiesExpanded = true;
+        this._stateIconRowsMain = [];
+        this._stateIconRowsAdditional = new Map();
+    }
+
+    public setConfig(config: MultipleEntityRowConfig): void {
+        this._config = config;
+        const maxAdditionalTab = config.entities?.length ?? 0;
+        if (this._selectedTab > maxAdditionalTab) {
+            this._selectedTab = maxAdditionalTab;
+        }
+        this._clipboardEntity = this._readClipboard();
+
+        // Sync state_icon row drafts with config. The match-skip preserves any empty rows the
+        // user is mid-typing - without it, our own config-changed round-trips would wipe the
+        // draft on every keystroke.
+        if (!this._stateIconRowsMatch(this._stateIconRowsMain, config.state_icon)) {
+            this._stateIconRowsMain = Object.entries(config.state_icon ?? {});
+        }
+        const next = new Map<number, StateIconRows>();
+        config.entities?.forEach((e, i) => {
+            const target = isObject(e) ? (e as EntityConfig).state_icon : undefined;
+            const existing = this._stateIconRowsAdditional.get(i);
+            if (existing && this._stateIconRowsMatch(existing, target)) {
+                next.set(i, existing);
+            } else if (target) {
+                next.set(i, Object.entries(target));
+            }
+        });
+        this._stateIconRowsAdditional = next;
+    }
+
+    /** True when the filtered form of `rows` (empty pairs dropped) structurally equals `target`.
+     * Used to skip the setConfig sync when local drafts already match the config handed back. */
+    private _stateIconRowsMatch(rows: StateIconRows, target: Record<string, string> | undefined): boolean {
+        const filtered: Record<string, string> = {};
+        for (const [k, v] of rows) {
+            if (k.trim() && v.trim()) filtered[k.trim()] = v.trim();
+        }
+        const tgt = target ?? {};
+        const keys = Object.keys(filtered);
+        return keys.length === Object.keys(tgt).length && keys.every((k) => filtered[k] === tgt[k]);
+    }
+
+    private _readClipboard(): EntityConfig | undefined {
+        try {
+            const raw = sessionStorage.getItem(CLIPBOARD_KEY);
+            if (!raw) return undefined;
+            const parsed = JSON.parse(raw);
+            if (parsed && typeof parsed === 'object') return parsed as EntityConfig;
+        } catch {
+            /* unavailable/invalid sessionStorage just disables paste */
+        }
+        return undefined;
+    }
+
+    private _writeClipboard(entity: EntityConfig): void {
+        try {
+            sessionStorage.setItem(CLIPBOARD_KEY, JSON.stringify(entity));
+            this._clipboardEntity = entity;
+        } catch {
+            /* ignore */
+        }
+    }
+
+    // ha-tab-group is a lazy-loaded HA chunk that may not be defined yet when the editor mounts;
+    // a plain-button tab bar renders as fallback (see the HA lazy-loading gotcha).
+    private get _hasNativeTabs(): boolean {
+        return !!customElements.get('ha-tab-group') && !!customElements.get('ha-tab-group-tab');
+    }
+
+    static styles = css`
+        ha-expansion-panel {
+            display: block;
+            margin-top: 12px;
+        }
+        .panel-content {
+            padding: 12px 0;
+        }
+        .tabs-row {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            border-bottom: 1px solid var(--divider-color, #e0e0e0);
+            margin-bottom: 8px;
+        }
+        ha-tab-group.tabs {
+            flex: 1;
+            min-width: 0;
+        }
+        .tab-bar--fallback {
+            display: flex;
+            flex: 1;
+            gap: 4px;
+            overflow-x: auto;
+        }
+        .tab-bar--fallback .tab {
+            padding: 8px 12px;
+            cursor: pointer;
+            border: 1px solid transparent;
+            border-bottom: none;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+            white-space: nowrap;
+            color: var(--secondary-text-color);
+            background: transparent;
+            font: inherit;
+        }
+        .tab-bar--fallback .tab--active {
+            background: var(--card-background-color);
+            border-color: var(--divider-color);
+            color: var(--primary-text-color);
+        }
+        .tabs__add {
+            flex: 0 0 auto;
+        }
+        .child-actions {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 0 8px;
+        }
+        .child-actions ha-icon-button[disabled] {
+            opacity: 0.4;
+            pointer-events: none;
+        }
+        .child-editor {
+            border: 1px solid var(--divider-color, #e0e0e0);
+            border-radius: 8px;
+            padding: 8px;
+            background: var(--card-background-color);
+        }
+        .secondary-sub-form {
+            margin-top: 8px;
+        }
+        .state-icon-rows {
+            margin-top: 4px;
+        }
+        .state-icon-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+        .state-icon-row .state-icon-form {
+            flex: 1;
+            min-width: 0;
+        }
+        .state-icon-row ha-icon-button {
+            flex: 0 0 auto;
+        }
+        .state-icon-add {
+            margin-top: 4px;
+            padding: 6px 14px;
+            background: transparent;
+            border: 1px dashed var(--divider-color, #e0e0e0);
+            border-radius: 4px;
+            color: var(--primary-color);
+            cursor: pointer;
+            font: inherit;
+        }
+        .state-icon-add:hover {
+            background: var(--secondary-background-color);
+        }
+        .section-label {
+            margin-top: 16px;
+            margin-bottom: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--secondary-text-color);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .footer {
+            margin-top: 16px;
+            padding-top: 8px;
+            border-top: 1px solid var(--divider-color, #e0e0e0);
+            font-size: 11px;
+            color: var(--secondary-text-color);
+            text-align: right;
+        }
+    `;
+
+    protected render(): TemplateResult | typeof nothing {
+        if (!this.hass || !this._config) return nothing;
+
+        return html`
+            <ha-expansion-panel
+                .header=${'Entities'}
+                outlined
+                ?expanded=${this._entitiesExpanded}
+                @expanded-changed=${this._onEntitiesExpandedChanged}
+            >
+                ${this._renderEntitiesPanel()}
+            </ha-expansion-panel>
+
+            <div class="footer">v${process.env.PACKAGE_VERSION} · ${process.env.BUILD_TIME}</div>
+        `;
+    }
+
+    private _onEntitiesExpandedChanged = (ev: CustomEvent): void => {
+        const target = ev.target as { expanded?: boolean } | null;
+        if (typeof target?.expanded === 'boolean') {
+            this._entitiesExpanded = target.expanded;
+        }
+    };
+
+    private _computeLabel = (item: { name: string }): string => LABELS[item.name] ?? item.name;
+
+    // ── Entities panel: Main (tab 0) + Additional (tabs 1+) ─────────────
+
+    private _keyFor(index: number): string {
+        if (!this._keys.has(index)) {
+            this._keys.set(index, `${index}-${Math.random().toString(36).slice(2, 10)}`);
+        }
+        return this._keys.get(index)!;
+    }
+
+    private _renderEntitiesPanel(): TemplateResult {
+        const additional = this._config?.entities ?? [];
+        // Clamp at render time too: a state mutation can trigger a render while _selectedTab
+        // still points past the (just shrunk) entities list, before setConfig re-clamps it.
+        const idx = Math.min(this._selectedTab, additional.length);
+
+        return html`
+            <div class="panel-content">
+                <div class="tabs-row">
+                    ${this._hasNativeTabs
+                        ? html`
+                              <ha-tab-group class="tabs" @wa-tab-show=${this._onTabShow}>
+                                  <ha-tab-group-tab slot="nav" .panel=${0} .active=${idx === 0}>
+                                      Main
+                                  </ha-tab-group-tab>
+                                  ${additional.map(
+                                      (_e, i) => html`
+                                          <ha-tab-group-tab slot="nav" .panel=${i + 1} .active=${idx === i + 1}>
+                                              ${i + 1}
+                                          </ha-tab-group-tab>
+                                      `
+                                  )}
+                              </ha-tab-group>
+                          `
+                        : html`
+                              <div class="tab-bar--fallback" role="tablist">
+                                  <button
+                                      type="button"
+                                      class=${'tab ' + (idx === 0 ? 'tab--active' : '')}
+                                      role="tab"
+                                      aria-selected=${idx === 0 ? 'true' : 'false'}
+                                      aria-controls="mer-tab-panel"
+                                      @click=${() => (this._selectedTab = 0)}
+                                  >
+                                      Main
+                                  </button>
+                                  ${additional.map(
+                                      (_e, i) => html`
+                                          <button
+                                              type="button"
+                                              class=${'tab ' + (idx === i + 1 ? 'tab--active' : '')}
+                                              role="tab"
+                                              aria-selected=${idx === i + 1 ? 'true' : 'false'}
+                                              aria-controls="mer-tab-panel"
+                                              @click=${() => (this._selectedTab = i + 1)}
+                                          >
+                                              ${i + 1}
+                                          </button>
+                                      `
+                                  )}
+                              </div>
+                          `}
+                    <ha-icon-button
+                        class="tabs__add"
+                        .label=${'Add entity'}
+                        .path=${PATH_PLUS}
+                        @click=${this._addEntity}
+                    ></ha-icon-button>
+                </div>
+
+                <div id="mer-tab-panel" role="tabpanel">
+                    ${keyed(this._keyFor(idx), idx === 0 ? this._renderMainTab() : this._renderAdditionalTab(idx - 1))}
+                </div>
+            </div>
+        `;
+    }
+
+    private _renderMainTab(): TemplateResult {
+        // Main has no Move / Cut / Delete (it's the anchor entity, required). Secondary info is
+        // row-wide config, so it lives inside the Main tab rather than as a top-level panel.
+        return html`
+            <div class="child-actions">
+                <ha-icon-button
+                    .label=${'Copy main as template'}
+                    .path=${PATH_COPY}
+                    @click=${this._copyMainAsTemplate}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Paste as new entity'}
+                    .path=${PATH_PASTE}
+                    .disabled=${!this._clipboardEntity}
+                    @click=${this._pasteEntity}
+                ></ha-icon-button>
+            </div>
+            <div class="child-editor">
+                <ha-form
+                    .hass=${this.hass}
+                    .data=${this._mainFormData()}
+                    .schema=${MAIN_TAB_SCHEMA}
+                    .computeLabel=${this._computeLabel}
+                    @value-changed=${this._mainValueChanged}
+                ></ha-form>
+                <div class="section-label">Secondary info</div>
+                ${this._renderSecondaryInfoBlock()}
+                <div class="section-label">State-based icons</div>
+                ${this._renderStateIconRows('main')}
+                <div class="section-label">Custom CSS</div>
+                ${this._renderStylesBlock(this._config?.styles, (ev) => this._mainStylesChanged(ev))}
+            </div>
+        `;
+    }
+
+    private _renderStylesBlock(value: unknown, handler: (ev: CustomEvent) => void): TemplateResult {
+        return html`
+            <ha-code-editor
+                mode="yaml"
+                autocomplete-entities
+                autocomplete-icons
+                .hass=${this.hass}
+                .value=${stringifyStyles(value)}
+                @value-changed=${handler}
+            ></ha-code-editor>
+        `;
+    }
+
+    private _mainStylesChanged(ev: CustomEvent): void {
+        if (!this._config) return;
+        const parsed = parseStylesText((ev.detail as { value: string }).value);
+        this._updateConfig({ styles: Object.keys(parsed).length > 0 ? parsed : undefined });
+    }
+
+    private _additionalStylesChanged(ev: CustomEvent, index: number): void {
+        if (!this._config) return;
+        const parsed = parseStylesText((ev.detail as { value: string }).value);
+        const entities = [...(this._config.entities ?? [])];
+        const raw = entities[index];
+        const conf: EntityConfig = typeof raw === 'string' ? { entity: raw } : { ...raw };
+        if (Object.keys(parsed).length > 0) {
+            conf.styles = parsed;
+        } else {
+            delete conf.styles;
+        }
+        entities[index] = conf;
+        this._updateConfig({ entities });
+    }
+
+    // ── State-icon row-based UI ─────────────────────────────────────────
+
+    private _stateIconRowsFor(scope: 'main' | number): StateIconRows {
+        return scope === 'main' ? this._stateIconRowsMain : this._stateIconRowsAdditional.get(scope) ?? [];
+    }
+
+    /** Persist updated rows to local state AND propagate the filtered object form to
+     * config-changed. Empty rows (missing state or icon) stay in local state for editing but
+     * don't reach the YAML config. */
+    private _setStateIconRows(scope: 'main' | number, rows: StateIconRows): void {
+        if (scope === 'main') {
+            this._stateIconRowsMain = rows;
+        } else {
+            const next = new Map(this._stateIconRowsAdditional);
+            next.set(scope, rows);
+            this._stateIconRowsAdditional = next;
+        }
+
+        const filtered: Record<string, string> = {};
+        for (const [k, v] of rows) {
+            if (k.trim() && v.trim()) filtered[k.trim()] = v.trim();
+        }
+        const value = Object.keys(filtered).length > 0 ? filtered : undefined;
+
+        if (!this._config) return;
+        if (scope === 'main') {
+            this._updateConfig({ state_icon: value });
+        } else {
+            const entities = [...(this._config.entities ?? [])];
+            const raw = entities[scope];
+            const conf: EntityConfig = typeof raw === 'string' ? { entity: raw } : { ...raw };
+            if (value) {
+                conf.state_icon = value;
+            } else {
+                delete conf.state_icon;
+            }
+            entities[scope] = conf;
+            this._updateConfig({ entities });
+        }
+    }
+
+    private _renderStateIconRows(scope: 'main' | number): TemplateResult {
+        const rows = this._stateIconRowsFor(scope);
+
+        return html`
+            <div class="state-icon-rows">
+                ${rows.map(
+                    (entry, i) => html`
+                        <div class="state-icon-row">
+                            <ha-form
+                                class="state-icon-form"
+                                .hass=${this.hass}
+                                .data=${{ state: entry[0], icon: entry[1] }}
+                                .schema=${STATE_ICON_ROW_SCHEMA}
+                                .computeLabel=${STATE_ICON_ROW_LABEL}
+                                @value-changed=${(ev: CustomEvent) => {
+                                    const v = ev.detail.value as { state?: string; icon?: string };
+                                    const next = rows.map((e, j): [string, string] =>
+                                        j === i ? [v.state ?? '', v.icon ?? ''] : e
+                                    );
+                                    this._setStateIconRows(scope, next);
+                                }}
+                            ></ha-form>
+                            <ha-icon-button
+                                .label=${'Remove'}
+                                .path=${PATH_DELETE}
+                                @click=${() =>
+                                    this._setStateIconRows(
+                                        scope,
+                                        rows.filter((_, j) => j !== i)
+                                    )}
+                            ></ha-icon-button>
+                        </div>
+                    `
+                )}
+                <button
+                    type="button"
+                    class="state-icon-add"
+                    @click=${() => this._setStateIconRows(scope, [...rows, ['', '']])}
+                >
+                    + Add state
+                </button>
+            </div>
+        `;
+    }
+
+    private _renderAdditionalTab(additionalIndex: number): TemplateResult {
+        const rawEntity = this._config!.entities![additionalIndex];
+        const entityConfig: EntityConfig = typeof rawEntity === 'string' ? { entity: rawEntity } : rawEntity;
+        const lastAdditional = (this._config?.entities?.length ?? 1) - 1;
+
+        return html`
+            <div class="child-actions">
+                <ha-icon-button
+                    .label=${'Move before'}
+                    .path=${PATH_MOVE_BEFORE}
+                    .disabled=${additionalIndex === 0}
+                    @click=${() => this._moveAdditional(additionalIndex, -1)}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Move after'}
+                    .path=${PATH_MOVE_AFTER}
+                    .disabled=${additionalIndex === lastAdditional}
+                    @click=${() => this._moveAdditional(additionalIndex, 1)}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Copy entity'}
+                    .path=${PATH_COPY}
+                    @click=${() => this._copyAdditional(additionalIndex)}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Cut entity'}
+                    .path=${PATH_CUT}
+                    @click=${() => this._cutAdditional(additionalIndex)}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Paste from clipboard'}
+                    .path=${PATH_PASTE}
+                    .disabled=${!this._clipboardEntity}
+                    @click=${this._pasteEntity}
+                ></ha-icon-button>
+                <ha-icon-button
+                    .label=${'Delete entity'}
+                    .path=${PATH_DELETE}
+                    @click=${() => this._deleteAdditional(additionalIndex)}
+                ></ha-icon-button>
+            </div>
+            <div class="child-editor">
+                <ha-form
+                    .hass=${this.hass}
+                    .data=${unitToForm(entityConfig)}
+                    .schema=${ADDITIONAL_TAB_SCHEMA}
+                    .computeLabel=${this._computeLabel}
+                    @value-changed=${(ev: CustomEvent) => this._additionalValueChanged(ev, additionalIndex)}
+                ></ha-form>
+                <div class="section-label">State-based icons</div>
+                ${this._renderStateIconRows(additionalIndex)}
+                <div class="section-label">Custom CSS</div>
+                ${this._renderStylesBlock(entityConfig.styles, (ev: CustomEvent) =>
+                    this._additionalStylesChanged(ev, additionalIndex)
+                )}
+            </div>
+        `;
+    }
+
+    // Native <ha-tab-group> tab-show: the tab's `panel` value is the tab index.
+    private _onTabShow = (ev: CustomEvent): void => {
+        const name = (ev.detail as { name?: string })?.name;
+        if (name == null) return;
+        const idx = parseInt(name, 10);
+        if (!Number.isNaN(idx) && idx !== this._selectedTab) {
+            this._selectedTab = idx;
+        }
+    };
+
+    // ── Value-changed handlers ──────────────────────────────────────────
+
+    /** Form data for the Main tab: seeds show_state's runtime default (ON) so the toggle reads
+     * correctly for configs that don't set the key, and maps `unit: false` to its text form. */
+    private _mainFormData(): MultipleEntityRowConfig {
+        return unitToForm({ show_state: true, ...this._config! });
+    }
+
+    private _mainValueChanged = (ev: CustomEvent): void => {
+        if (!this._config) return;
+        const newConfig = unitFromForm({ ...(ev.detail.value as MultipleEntityRowConfig) });
+        // show_state: true is the seeded runtime default - strip the redundant key on the way
+        // back out so it doesn't pollute the YAML.
+        if (newConfig.show_state === true) delete newConfig.show_state;
+        fireEvent(this, 'config-changed', { config: newConfig });
+    };
+
+    private _additionalValueChanged = (ev: CustomEvent, additionalIndex: number): void => {
+        if (!this._config) return;
+        const entities = [...(this._config.entities ?? [])];
+        entities[additionalIndex] = unitFromForm(ev.detail.value as EntityConfig);
+        this._updateConfig({ entities });
+    };
+
+    // ── Mutating handlers (Main is protected) ───────────────────────────
+
+    private _addEntity = (): void => {
+        if (!this._config) return;
+        const entities = [...(this._config.entities ?? []), {} as EntityConfig];
+        this._selectedTab = entities.length; // last additional tab
+        this._keys.clear();
+        this._updateConfig({ entities });
+    };
+
+    private _deleteAdditional = (additionalIndex: number): void => {
+        if (!this._config) return;
+        const entities = [...(this._config.entities ?? [])];
+        entities.splice(additionalIndex, 1);
+        if (this._selectedTab > entities.length) {
+            this._selectedTab = entities.length;
+        }
+        this._keys.clear();
+        this._updateConfig({ entities: entities.length ? entities : undefined });
+    };
+
+    private _moveAdditional = (additionalIndex: number, delta: number): void => {
+        if (!this._config) return;
+        const entities = [...(this._config.entities ?? [])];
+        const target = additionalIndex + delta;
+        if (target < 0 || target >= entities.length) return;
+        [entities[additionalIndex], entities[target]] = [entities[target], entities[additionalIndex]];
+        this._selectedTab = target + 1; // tab index = additional index + 1
+        this._keys.clear();
+        this._updateConfig({ entities });
+    };
+
+    private _copyAdditional = (additionalIndex: number): void => {
+        const raw = this._config?.entities?.[additionalIndex];
+        if (raw == null) return;
+        this._writeClipboard(typeof raw === 'string' ? { entity: raw } : { ...raw });
+    };
+
+    private _cutAdditional = (additionalIndex: number): void => {
+        this._copyAdditional(additionalIndex);
+        this._deleteAdditional(additionalIndex);
+    };
+
+    /** Copy Main's per-entity-relevant fields as a clipboard template - useful to seed similar
+     * additional entities. Row-wide fields (column, image, show_state, state_header) are
+     * intentionally NOT copied since they don't apply to a sub-entity slot. */
+    private _copyMainAsTemplate = (): void => {
+        if (!this._config) return;
+        const tmpl: EntityConfig = {};
+        for (const k of MAIN_COPYABLE_FIELDS) {
+            const v = this._config[k];
+            if (v !== undefined) (tmpl as Record<string, any>)[k] = v;
+        }
+        this._writeClipboard(tmpl);
+    };
+
+    private _pasteEntity = (): void => {
+        if (!this._config) return;
+        const fresh = this._readClipboard();
+        if (!fresh) return;
+        const entities = [...(this._config.entities ?? []), fresh];
+        this._selectedTab = entities.length;
+        this._keys.clear();
+        this._updateConfig({ entities });
+    };
+
+    // ── Secondary info (polymorphic: text | generic token | entity object) ─
+
+    private _secondaryInfoMode(): SecondaryMode {
+        const si = this._config?.secondary_info;
+        if (si == null) return 'none';
+        if (typeof si === 'object') return 'entity';
+        if (SECONDARY_INFO_VALUES.includes(si)) return 'generic';
+        return 'text';
+    }
+
+    private _renderSecondaryInfoBlock(): TemplateResult {
+        const mode = this._secondaryInfoMode();
+        const si = this._config?.secondary_info;
+
+        return html`
+            <div>
+                <ha-form
+                    .hass=${this.hass}
+                    .data=${{ mode }}
+                    .schema=${SECONDARY_MODE_SCHEMA}
+                    .computeLabel=${() => 'Mode'}
+                    @value-changed=${this._secondaryModeChanged}
+                ></ha-form>
+                ${mode === 'text'
+                    ? html`<div class="secondary-sub-form">
+                          <ha-form
+                              .hass=${this.hass}
+                              .data=${{ text: si ?? '' }}
+                              .schema=${TEXT_SCHEMA}
+                              .computeLabel=${() => 'Custom text'}
+                              @value-changed=${this._secondaryTextChanged}
+                          ></ha-form>
+                      </div>`
+                    : nothing}
+                ${mode === 'generic'
+                    ? html`<div class="secondary-sub-form">
+                          <ha-form
+                              .hass=${this.hass}
+                              .data=${{ token: si }}
+                              .schema=${GENERIC_TOKEN_SCHEMA}
+                              .computeLabel=${() => 'HA built-in'}
+                              @value-changed=${this._secondaryTokenChanged}
+                          ></ha-form>
+                      </div>`
+                    : nothing}
+                ${mode === 'entity'
+                    ? html`<div class="secondary-sub-form">
+                          <ha-form
+                              .hass=${this.hass}
+                              .data=${unitToForm(si as EntityConfig)}
+                              .schema=${ADDITIONAL_TAB_SCHEMA}
+                              .computeLabel=${this._computeLabel}
+                              @value-changed=${this._secondaryEntityChanged}
+                          ></ha-form>
+                      </div>`
+                    : nothing}
+            </div>
+        `;
+    }
+
+    private _secondaryModeChanged = (ev: CustomEvent): void => {
+        if (!this._config) return;
+        const newMode = ev.detail.value.mode as SecondaryMode;
+        if (newMode === this._secondaryInfoMode()) return;
+        let nextSi: MultipleEntityRowConfig['secondary_info'] | undefined;
+        switch (newMode) {
+            case 'none':
+                nextSi = undefined;
+                break;
+            case 'text':
+                nextSi = '';
+                break;
+            case 'generic':
+                nextSi = 'last-changed';
+                break;
+            case 'entity':
+                nextSi = { entity: this._config.entity };
+                break;
+        }
+        this._updateConfig({ secondary_info: nextSi });
+    };
+
+    private _secondaryTextChanged = (ev: CustomEvent): void => {
+        this._updateConfig({ secondary_info: ev.detail.value.text });
+    };
+
+    private _secondaryTokenChanged = (ev: CustomEvent): void => {
+        this._updateConfig({ secondary_info: ev.detail.value.token });
+    };
+
+    private _secondaryEntityChanged = (ev: CustomEvent): void => {
+        this._updateConfig({ secondary_info: unitFromForm(ev.detail.value as EntityConfig) });
+    };
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private _updateConfig(patch: Partial<MultipleEntityRowConfig>): void {
+        if (!this._config) return;
+        const next: Record<string, any> = { ...this._config };
+        for (const [k, v] of Object.entries(patch)) {
+            if (v === undefined) delete next[k];
+            else next[k] = v;
+        }
+        fireEvent(this, 'config-changed', { config: next });
+    }
+}
+
+customElements.define('multiple-entity-row-editor', MultipleEntityRowEditor);

--- a/src/editor_schemas.ts
+++ b/src/editor_schemas.ts
@@ -1,0 +1,130 @@
+// ha-form schemas for the visual editor. Adapted from the duczz/ha-multiple-entity-row fork.
+
+const FORMAT_OPTIONS = [
+    { value: '', label: 'No format' },
+    { value: 'brightness', label: 'Brightness (0-255 → %)' },
+    { value: 'percent', label: 'Percent (value × 100 → x %)' },
+    { value: 'duration', label: 'Duration (seconds → h:mm:ss)' },
+    { value: 'duration-m', label: 'Duration (milliseconds)' },
+    { value: 'duration-h', label: 'Duration (hours)' },
+    { value: 'precision0', label: 'Precision 0 decimals' },
+    { value: 'precision1', label: 'Precision 1 decimal' },
+    { value: 'precision2', label: 'Precision 2 decimals' },
+    { value: 'precision3', label: 'Precision 3 decimals' },
+    // The runtime supports precision4..9 and kilo/mega/milli digit suffixes too; those stay
+    // YAML-only so the dropdown isn't cluttered with rarely-used variants.
+    { value: 'kilo', label: 'Kilo (value / 1,000)' },
+    { value: 'mega', label: 'Mega (value / 1,000,000)' },
+    { value: 'milli', label: 'Milli (value × 1,000)' },
+    { value: 'invert', label: 'Invert (value × -1)' },
+    { value: 'position', label: 'Position (100 - value)' },
+    { value: 'celsius_to_fahrenheit', label: '°C → °F' },
+    { value: 'fahrenheit_to_celsius', label: '°F → °C' },
+    { value: 'upper', label: 'Text: UPPERCASE' },
+    { value: 'lower', label: 'Text: lowercase' },
+    { value: 'capitalize', label: 'Text: Capitalize first letter' },
+    { value: 'title', label: 'Text: Title Case' },
+    { value: 'relative', label: 'Timestamp: relative' },
+    { value: 'total', label: 'Timestamp: total' },
+    { value: 'date', label: 'Timestamp: date' },
+    { value: 'time', label: 'Timestamp: time' },
+    { value: 'datetime', label: 'Timestamp: date + time' },
+];
+
+// Tab "1" - the main entity. Writes to TOP-LEVEL config keys (config.entity, config.name, ...).
+export const MAIN_TAB_SCHEMA = [
+    { name: 'entity', required: true, selector: { entity: {} } },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'name', selector: { text: {} } },
+            { name: 'attribute', selector: { text: {} } },
+        ],
+    },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'unit', selector: { text: {} } },
+            { name: 'icon', selector: { icon: {} } },
+        ],
+    },
+    { name: 'icon_color', selector: { text: {} } },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'show_state', default: true, selector: { boolean: {} } },
+            { name: 'state_color', selector: { boolean: {} } },
+        ],
+    },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'toggle', selector: { boolean: {} } },
+            { name: 'column', selector: { boolean: {} } },
+        ],
+    },
+    { name: 'hide_unavailable', selector: { boolean: {} } },
+    { name: 'state_header', selector: { text: {} } },
+    { name: 'image', selector: { text: {} } },
+    { name: 'format', selector: { select: { mode: 'dropdown', options: FORMAT_OPTIONS } } },
+    // Row-level actions live in the Main tab, in the same format as the per-entity ones -
+    // a separate "Interactions" panel on screen alongside a tab's action selectors read as
+    // two competing blocks.
+    { name: 'tap_action', selector: { ui_action: { default_action: 'more-info' } } },
+    { name: 'hold_action', selector: { ui_action: { default_action: 'none' } } },
+    { name: 'double_tap_action', selector: { ui_action: { default_action: 'none' } } },
+];
+
+// Tabs "2".."N" - additional entities. Writes to config.entities[i-1]. Also reused for the
+// secondary-info entity form, where the action selectors are inert (secondary info has no
+// pointer handlers) - harmless.
+export const ADDITIONAL_TAB_SCHEMA = [
+    { name: 'entity', selector: { entity: {} } },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'name', selector: { text: {} } },
+            { name: 'attribute', selector: { text: {} } },
+        ],
+    },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'unit', selector: { text: {} } },
+            { name: 'icon', selector: { icon: {} } },
+        ],
+    },
+    { name: 'icon_color', selector: { text: {} } },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'state_color', selector: { boolean: {} } },
+            { name: 'toggle', selector: { boolean: {} } },
+        ],
+    },
+    { name: 'hide_unavailable', selector: { boolean: {} } },
+    { name: 'format', selector: { select: { mode: 'dropdown', options: FORMAT_OPTIONS } } },
+    { name: 'tap_action', selector: { ui_action: { default_action: 'more-info' } } },
+    { name: 'hold_action', selector: { ui_action: { default_action: 'none' } } },
+    { name: 'double_tap_action', selector: { ui_action: { default_action: 'none' } } },
+];
+
+export const LABELS: Record<string, string> = {
+    entity: 'Entity',
+    attribute: 'Attribute',
+    name: 'Name override',
+    unit: 'Unit',
+    icon: 'Icon',
+    icon_color: 'Icon color (CSS value, e.g. red, #ff0000, var(--my-color))',
+    image: 'Image URL',
+    format: 'Format',
+    show_state: 'Show main entity state',
+    state_header: 'State header label',
+    state_color: 'State color',
+    column: 'Column layout',
+    toggle: 'Show as toggle',
+    hide_unavailable: 'Hide if unavailable',
+    tap_action: 'Tap action',
+    hold_action: 'Hold action',
+    double_tap_action: 'Double-tap action',
+};

--- a/src/entity.js
+++ b/src/entity.js
@@ -20,7 +20,8 @@ export const computeEntity = (entityId) => entityId.substr(entityId.indexOf('.')
 // scale/sign transform, since arithmetic (e.g. `value / 1000`) coerces the string to a number
 // before it reaches formatNumber, losing the "keep original decimal digits" behavior it would
 // otherwise apply (see #304).
-const decimalDigits = (value) => (typeof value === 'string' && value.includes('.') ? value.split('.')[1].length : undefined);
+const decimalDigits = (value) =>
+    typeof value === 'string' && value.includes('.') ? value.split('.')[1].length : undefined;
 
 // Shared implementation for the kilo/mega/milli formats: divides by the given factor, and applies
 // either the default 2-decimal cap (bare `kilo`/`mega`/`milli`, digits === undefined) or an
@@ -30,7 +31,10 @@ const scaledFormat = (value, divisor, digits, locale) => {
         return formatNumber(value / divisor, locale, { maximumFractionDigits: 2 });
     }
     const precision = parseInt(digits, 10);
-    return formatNumber(value / divisor, locale, { minimumFractionDigits: precision, maximumFractionDigits: precision });
+    return formatNumber(value / divisor, locale, {
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision,
+    });
 };
 
 // precision<N>/kilo<N>/mega<N>/milli<N> parse a trailing digit off the format string. `kilo`,
@@ -159,14 +163,18 @@ export const entityStateDisplay = (hass, stateObj, config) => {
             value = formatNumber(
                 value - value * 2,
                 hass.locale,
-                precision !== undefined ? { minimumFractionDigits: precision, maximumFractionDigits: precision } : undefined
+                precision !== undefined
+                    ? { minimumFractionDigits: precision, maximumFractionDigits: precision }
+                    : undefined
             );
         } else if (config.format === 'position') {
             const precision = decimalDigits(value);
             value = formatNumber(
                 100 - value,
                 hass.locale,
-                precision !== undefined ? { minimumFractionDigits: precision, maximumFractionDigits: precision } : undefined
+                precision !== undefined
+                    ? { minimumFractionDigits: precision, maximumFractionDigits: precision }
+                    : undefined
             );
         } else if (config.format === 'celsius_to_fahrenheit') {
             value = formatNumber(value * 1.8 + 32, hass.locale, { maximumFractionDigits: 0 });
@@ -185,7 +193,8 @@ export const entityStateDisplay = (hass, stateObj, config) => {
         // A missing attribute is undefined, not a number or a real string - render an empty value
         // rather than the literal string "undefined" (same class of bug as #225, in a code path
         // that fix didn't cover since it only applies when a `format:` is configured).
-        const displayValue = value === undefined || value === null ? '' : isNaN(value) ? value : formatNumber(value, hass.locale);
+        const displayValue =
+            value === undefined || value === null ? '' : isNaN(value) ? value : formatNumber(value, hass.locale);
         return `${displayValue}${unit ? ` ${unit}` : ''}`;
     }
 

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { checkEntity, computeEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
+import {
+    checkEntity,
+    computeEntity,
+    entityName,
+    entityStateDisplay,
+    entityStyles,
+    iconColorCss,
+    stateIcon,
+} from './entity';
 import { NumberFormat } from './lib/constants';
 
 const hass = {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,9 @@
+// Build-time constants injected by webpack DefinePlugin (see webpack.config.js).
+declare const process: {
+    env: {
+        NODE_ENV: string;
+        BUILD_TIME: string;
+        BUILD_COMMIT: string;
+        PACKAGE_VERSION: string;
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,9 @@ import { css, html, LitElement } from 'lit';
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
 import { checkEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
-import {
-    fireEvent,
-    getEntityIds,
-    hasConfigOrEntitiesChanged,
-    hasGenericSecondaryInfo,
-    hideIf,
-    isObject,
-} from './util';
+import { fireEvent, getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
 import { style } from './styles';
+import './editor';
 
 // hui-generic-entity-row attaches its own tap/hold/double-tap detection to the outer row
 // element unconditionally (see the catchInteraction comment in render() below) via mousedown/
@@ -29,6 +23,16 @@ console.info(
 );
 
 class MultipleEntityRow extends LitElement {
+    static getConfigElement() {
+        return document.createElement('multiple-entity-row-editor');
+    }
+
+    static getStubConfig(hass, entities) {
+        // Prefer a sensor for the stub so the row shows a value out of the box.
+        const entity = entities?.find((e) => e.startsWith('sensor.')) ?? entities?.[0] ?? '';
+        return { entity };
+    }
+
     static get properties() {
         return {
             _hass: Object,
@@ -116,7 +120,9 @@ class MultipleEntityRow extends LitElement {
             .catchInteraction=${true}
         >
             <div class="${this.config.column ? 'entities-column' : 'entities-row'}">
-                ${this.entities.map((entity, index) => this.renderEntity(entity.stateObj, entity, index))}${this.renderMainEntity()}
+                ${this.entities.map((entity, index) =>
+                    this.renderEntity(entity.stateObj, entity, index)
+                )}${this.renderMainEntity()}
             </div>
         </hui-generic-entity-row>`;
     }
@@ -284,8 +290,8 @@ class MultipleEntityRow extends LitElement {
         const actionConfig = dblClick
             ? config.double_tap_action
             : hold
-              ? config.hold_action
-              : config.tap_action ?? { action: 'more-info' };
+            ? config.hold_action
+            : config.tap_action ?? { action: 'more-info' };
         if (!actionConfig || actionConfig.action === 'none') {
             return;
         }
@@ -302,3 +308,11 @@ class MultipleEntityRow extends LitElement {
 }
 
 customElements.define('multiple-entity-row', MultipleEntityRow);
+
+// Registers the row with HA's card/row pickers so it's discoverable in the UI.
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: 'multiple-entity-row',
+    name: 'Multiple Entity Row',
+    description: 'Show multiple entity states and attributes on a single entity row',
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -168,7 +168,7 @@ describe('multiple-entity-row', () => {
             expect(el.getGestureHandlers('main', 'sensor.main', el.config)).toBe(main);
         });
 
-        it('dispatches using only that entity\'s own action config, not the main row\'s', () => {
+        it("dispatches using only that entity's own action config, not the main row's", () => {
             const sub = el.getGestureHandlers('sub-0', 'sensor.a', el.config.entities[0]);
             sub.onDown();
             sub.onUp();
@@ -183,7 +183,11 @@ describe('multiple-entity-row', () => {
         // Handlers are cached per key until the next setConfig, so these tests reset the config
         // (clearing the cache) rather than passing an ad-hoc config for an already-cached key.
         it('dispatches a hold to hold_action for a sub-entity', () => {
-            const subConfig = { entity: 'sensor.a', tap_action: { action: 'toggle' }, hold_action: { action: 'more-info' } };
+            const subConfig = {
+                entity: 'sensor.a',
+                tap_action: { action: 'toggle' },
+                hold_action: { action: 'more-info' },
+            };
             el.setConfig({ entity: 'sensor.main', entities: [subConfig] });
             const sub = el.getGestureHandlers('sub-0', 'sensor.a', subConfig);
             sub.onDown();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,85 @@
+// Config and hass typings for the card and its editor. Adapted from the
+// duczz/ha-multiple-entity-row fork's types.ts, adjusted to this card's schema.
+
+export type LooseObject = Record<string, any>;
+
+export interface HassEntity {
+    entity_id: string;
+    state: string;
+    attributes: Record<string, any>;
+    last_changed?: string;
+    last_updated?: string;
+}
+
+export interface HASS {
+    states: Record<string, HassEntity>;
+    locale: { language: string; number_format?: string; time_format?: string; [key: string]: any };
+    entities?: Record<string, any>;
+    localize: (key: string, ...args: any[]) => string;
+    formatEntityState?: (stateObj: HassEntity, state?: string) => string;
+    formatEntityAttributeValue?: (stateObj: HassEntity, attribute: string, value?: any) => string;
+    formatEntityName?: (entityOrId: HassEntity | string, name?: string) => string;
+    callService: (domain: string, service: string, data?: LooseObject) => Promise<any>;
+    [key: string]: any;
+}
+
+export interface ActionConfig {
+    // HA 2024.8 renamed call-service → perform-action; the ui_action selector emits it, and
+    // hass-action handles both. 'assist' arrived alongside.
+    action:
+        | 'more-info'
+        | 'toggle'
+        | 'call-service'
+        | 'perform-action'
+        | 'assist'
+        | 'navigate'
+        | 'url'
+        | 'fire-dom-event'
+        | 'none';
+    entity?: string;
+    [key: string]: any;
+}
+
+export interface HideIfObject {
+    above?: number;
+    below?: number;
+    value?: any | any[];
+    entity?: string;
+    attribute?: string;
+}
+
+interface EntityOptions {
+    format?: string;
+    attribute?: string;
+    unit?: string | false;
+    name?: string | false;
+    icon?: string | boolean;
+    icon_color?: string;
+    state_icon?: Record<string, string>;
+    state_color?: boolean;
+    toggle?: boolean;
+    hide_unavailable?: boolean;
+    hide_if?: any | any[] | HideIfObject;
+    styles?: Record<string, string>;
+    default?: string;
+    tap_action?: ActionConfig;
+    hold_action?: ActionConfig;
+    double_tap_action?: ActionConfig;
+}
+
+export interface EntityConfig extends EntityOptions {
+    entity?: string;
+}
+
+export interface MultipleEntityRowConfig extends EntityOptions {
+    type: string;
+    entity: string;
+    show_state?: boolean;
+    state_header?: string;
+    image?: string;
+    column?: boolean;
+    // HA 2026.7+'s row editor renames `format` to `time_format` on save (see #386).
+    time_format?: string;
+    entities?: (string | EntityConfig)[];
+    secondary_info?: string | EntityConfig;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "lib": ["ES2021", "DOM", "DOM.Iterable"],
+        "strict": true,
+        // .js and .ts coexist during the incremental migration; JS isn't type-checked yet.
+        "allowJs": true,
+        "checkJs": false,
+        // tsc is a type-checker only - babel does the actual compilation in webpack.
+        "noEmit": true,
+        // Lit reactive properties are declared via `declare` fields / static properties, not
+        // decorators; define-semantics class fields would shadow Lit's accessors, so keep the
+        // legacy behavior (this also matches what babel emits).
+        "useDefineForClassFields": false,
+        "skipLibCheck": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["src/**/*"]
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,13 +2,13 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        include: ['src/**/*.test.js'],
+        include: ['src/**/*.test.{js,ts}'],
         environment: 'node',
         coverage: {
             provider: 'v8',
             reporter: ['text', 'html', 'lcov'],
-            include: ['src/**/*.js'],
-            exclude: ['src/**/*.test.js'],
+            include: ['src/**/*.{js,ts}'],
+            exclude: ['src/**/*.test.{js,ts}', 'src/**/*.d.ts'],
         },
     },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,15 +22,25 @@ module.exports = {
         filename: 'multiple-entity-row.js',
         path: path.resolve(__dirname),
     },
+    resolve: {
+        extensions: ['.ts', '.js'],
+    },
     module: {
         rules: [
             {
-                test: /\.js$/,
+                test: /\.[jt]s$/,
                 exclude: /(node_modules)/,
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env'],
+                        // Babel only strips types; type CHECKING runs as 'tsc --noEmit' in the
+                        // lint step, so a type error fails the build there.
+                        presets: [
+                            '@babel/preset-env',
+                            // allowDeclareFields: `declare` fields type Lit reactive properties
+                            // without emitting real class fields that would shadow the accessors.
+                            ['@babel/preset-typescript', { allowDeclareFields: true }],
+                        ],
                     },
                 },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
+"@babel/plugin-syntax-jsx@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz#d49a3b3e6b52e5be6740022317580234a6a47357"
@@ -678,6 +692,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
+"@babel/plugin-transform-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
+  integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-syntax-typescript" "^7.29.7"
+
 "@babel/plugin-transform-unicode-escapes@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz#1e99554b0cddfd650d649a9f2b996049893e5720"
@@ -794,6 +819,17 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
+
+"@babel/preset-typescript@^7.27.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz#de9be1f47b785c979ec7b3a71f4cd8bae5267b62"
+  integrity sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-syntax-jsx" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-typescript" "^7.29.7"
 
 "@babel/template@^7.29.7":
   version "7.29.7"
@@ -1005,14 +1041,14 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
   integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
   integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/regexpp@^4.6.1":
+"@eslint-community/regexpp@^4.12.2", "@eslint-community/regexpp@^4.6.1":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
@@ -1300,6 +1336,102 @@
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@typescript-eslint/eslint-plugin@^8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz#1736dcdca6cae3359d818456a47d18b674761f7f"
+  integrity sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==
+  dependencies:
+    "@eslint-community/regexpp" "^4.12.2"
+    "@typescript-eslint/scope-manager" "8.62.1"
+    "@typescript-eslint/type-utils" "8.62.1"
+    "@typescript-eslint/utils" "8.62.1"
+    "@typescript-eslint/visitor-keys" "8.62.1"
+    ignore "^7.0.5"
+    natural-compare "^1.4.0"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/parser@^8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.62.1.tgz#d3f7ba18f1bf78bfb7256fea021d1927b48e7080"
+  integrity sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.62.1"
+    "@typescript-eslint/types" "8.62.1"
+    "@typescript-eslint/typescript-estree" "8.62.1"
+    "@typescript-eslint/visitor-keys" "8.62.1"
+    debug "^4.4.3"
+
+"@typescript-eslint/project-service@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.62.1.tgz#78d880eb1cf6859b5ec263d04f95403e9f90ae47"
+  integrity sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.62.1"
+    "@typescript-eslint/types" "^8.62.1"
+    debug "^4.4.3"
+
+"@typescript-eslint/scope-manager@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz#7ee65e9a6eb3ccdc4816593a4ff38840306de88a"
+  integrity sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==
+  dependencies:
+    "@typescript-eslint/types" "8.62.1"
+    "@typescript-eslint/visitor-keys" "8.62.1"
+
+"@typescript-eslint/tsconfig-utils@8.62.1", "@typescript-eslint/tsconfig-utils@^8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz#e2b5f24fe721044189cb7e81117c96d75979d627"
+  integrity sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==
+
+"@typescript-eslint/type-utils@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz#ebd30b13bacb13070917259a23309cf644121f9a"
+  integrity sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==
+  dependencies:
+    "@typescript-eslint/types" "8.62.1"
+    "@typescript-eslint/typescript-estree" "8.62.1"
+    "@typescript-eslint/utils" "8.62.1"
+    debug "^4.4.3"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/types@8.62.1", "@typescript-eslint/types@^8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.62.1.tgz#c58be954e483b2fc98275374d5bcb40b99842dc1"
+  integrity sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==
+
+"@typescript-eslint/typescript-estree@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz#98c1bb17635d5b026b24193a8d29188ac64380ff"
+  integrity sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==
+  dependencies:
+    "@typescript-eslint/project-service" "8.62.1"
+    "@typescript-eslint/tsconfig-utils" "8.62.1"
+    "@typescript-eslint/types" "8.62.1"
+    "@typescript-eslint/visitor-keys" "8.62.1"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/utils@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.62.1.tgz#1622b75c7e6df308181dd0b44855dc4228da0457"
+  integrity sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.62.1"
+    "@typescript-eslint/types" "8.62.1"
+    "@typescript-eslint/typescript-estree" "8.62.1"
+
+"@typescript-eslint/visitor-keys@8.62.1":
+  version "8.62.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz#499657d77ffafb8a99eb1d6c97847ca430234722"
+  integrity sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==
+  dependencies:
+    "@typescript-eslint/types" "8.62.1"
+    eslint-visitor-keys "^5.0.0"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.3.2"
@@ -1645,6 +1777,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 baseline-browser-mapping@^2.10.38:
   version "2.10.40"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz#f372c8eb36ff4ad0b5e7ae467014abef124554ba"
@@ -1664,6 +1801,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^5.0.5:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+  dependencies:
+    balanced-match "^4.0.2"
 
 browserslist@^4.24.0, browserslist@^4.28.1:
   version "4.28.4"
@@ -1923,6 +2067,11 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
 eslint@^8.41.0:
   version "8.57.1"
@@ -2207,6 +2356,11 @@ ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -2533,6 +2687,13 @@ mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
+minimatch@^10.2.2:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"
@@ -2901,7 +3062,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3:
+semver@^7.5.3, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -3063,6 +3224,11 @@ tr46@^6.0.0:
   dependencies:
     punycode "^2.3.1"
 
+ts-api-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
+  integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -3074,6 +3240,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 undici-types@~8.3.0:
   version "8.3.0"


### PR DESCRIPTION
## Summary
Adds a `ha-form`-based visual editor, reachable from the entities card's UI editor when editing a `custom:multiple-entity-row` row. Adapted from the [duczz/ha-multiple-entity-row](https://github.com/duczz/ha-multiple-entity-row) fork — thanks @duczz.

- Tabbed layout: **Main** tab (top-level config + row actions + secondary info) and numbered tabs for each additional entity, with add / reorder / copy / cut / paste / delete and a clipboard scoped to the browser tab
- Polymorphic secondary-info editor (none / custom text / HA token / entity-based)
- State-based icon rows and per-entity custom CSS (`ha-code-editor`)
- Tap/hold/double-tap action selectors per entity, and for the row in the Main tab
- Registered via `getConfigElement` / `getStubConfig` + `window.customCards`

Also sets up incremental TypeScript migration: `.ts`/`.js` coexist, Babel strips types in webpack, and `tsc --noEmit` type-checks in `yarn lint`. New code is TS; existing modules migrate when touched. (Gotcha encoded in the commit: yarn resolves `@babel/preset-typescript` to the Babel 8 prerelease, which silently fails to strip generics under a Babel 7 core — pinned to 7.x.)

## Test plan
- [x] `yarn build` (lint + type-check + 170 tests + webpack) passes; 20 new editor tests
- [x] Verified live in a local HA instance: tabbed editing, entity add/reorder/copy/paste, state-icon rows, custom CSS round-trip, YAML round-trips preserve existing configs