### PR TITLE
Add show_state_first option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | image             | string        |                                     | Show an image instead of icon                    |
 | toggle            | bool          | `false`                             | Display a toggle (if supported) instead of state |
 | show_state        | bool          | `true`                              | Set to `false` to hide the main entity           |
+| show_state_first  | bool          | `false`                             | Show the main state before other entities        |
 | state_header      | string        |                                     | Show header text above the main entity state     |
 | state_color       | bool          | `false`                             | Enable colored icon when entity is active        |
 | column            | bool          | `false`                             | Show entities in a column instead of a row       |

--- a/src/editor_schemas.ts
+++ b/src/editor_schemas.ts
@@ -63,7 +63,13 @@ export const MAIN_TAB_SCHEMA = [
             { name: 'column', selector: { boolean: {} } },
         ],
     },
-    { name: 'hide_unavailable', selector: { boolean: {} } },
+    {
+        type: 'grid',
+        schema: [
+            { name: 'show_state_first', selector: { boolean: {} } },
+            { name: 'hide_unavailable', selector: { boolean: {} } },
+        ],
+    },
     { name: 'state_header', selector: { text: {} } },
     { name: 'image', selector: { text: {} } },
     { name: 'format', selector: { select: { mode: 'dropdown', options: FORMAT_OPTIONS } } },
@@ -119,6 +125,7 @@ export const LABELS: Record<string, string> = {
     image: 'Image URL',
     format: 'Format',
     show_state: 'Show main entity state',
+    show_state_first: 'State before entities',
     state_header: 'State header label',
     state_color: 'State color',
     column: 'Column layout',

--- a/src/index.js
+++ b/src/index.js
@@ -120,9 +120,13 @@ class MultipleEntityRow extends LitElement {
             .catchInteraction=${true}
         >
             <div class="${this.config.column ? 'entities-column' : 'entities-row'}">
-                ${this.entities.map((entity, index) =>
-                    this.renderEntity(entity.stateObj, entity, index)
-                )}${this.renderMainEntity()}
+                ${this.config.show_state_first
+                    ? html`${this.renderMainEntity()}${this.entities.map((entity, index) =>
+                          this.renderEntity(entity.stateObj, entity, index)
+                      )}`
+                    : html`${this.entities.map((entity, index) =>
+                          this.renderEntity(entity.stateObj, entity, index)
+                      )}${this.renderMainEntity()}`}
             </div>
         </hui-generic-entity-row>`;
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -97,6 +97,31 @@ describe('multiple-entity-row', () => {
         expect(el.entities[0].stateObj.entity_id).toBe('sensor.a');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/384
+    it('renders the main state before sub-entities with show_state_first', async () => {
+        el.setConfig({ entity: 'sensor.main', show_state_first: true, entities: ['sensor.a'] });
+        el.hass = buildHass({
+            'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+            'sensor.a': { entity_id: 'sensor.a', state: 'off', attributes: {} },
+        });
+        await flushRender(el);
+        const entities = [...el.shadowRoot.querySelectorAll('.entity')];
+        expect(entities).toHaveLength(2);
+        expect(entities[0].classList.contains('state')).toBe(true);
+    });
+
+    it('renders the main state last by default', async () => {
+        el.setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+        el.hass = buildHass({
+            'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+            'sensor.a': { entity_id: 'sensor.a', state: 'off', attributes: {} },
+        });
+        await flushRender(el);
+        const entities = [...el.shadowRoot.querySelectorAll('.entity')];
+        expect(entities).toHaveLength(2);
+        expect(entities[entities.length - 1].classList.contains('state')).toBe(true);
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/227 - top-level
     // hide_if/hide_unavailable were silently ignored on the main entity.
     describe('main-row hiding', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface MultipleEntityRowConfig extends EntityOptions {
     type: string;
     entity: string;
     show_state?: boolean;
+    show_state_first?: boolean;
     state_header?: string;
     image?: string;
     column?: boolean;


### PR DESCRIPTION
## Summary
New `show_state_first` boolean renders the main state before the additional entities instead of after. Also exposed as a toggle in the visual editor's Main tab.

Fixes #384.

## Test plan
- [x] `yarn build` (lint + type-check + 172 tests + webpack) passes; ordering tests verified to fail without the change
- [x] Verified live in a local HA instance