### PR TITLE
Support combining numeric formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ None of `kilo`/`mega`/`milli`/`invert`/`position` change the displayed unit — 
   unit: kW
 ```
 
+Numeric formats can be **combined** comma-separated — the value flows through each in turn and is formatted once at the end. An explicit `precision<N>` controls the decimals wherever it appears; otherwise the last format's own default applies:
+
+```yaml
+format: invert, precision3   # -18.123
+format: kilo, precision1     # 1500 -> 1.5
+format: invert, kilo3        # 1500 -> -1.500
+```
+
+Only number-transforming formats compose (`brightness`, `percent`, `invert`, `position`, `kilo`/`mega`/`milli`, `precision`, temperature conversions) — durations, timestamps and text transforms cannot be combined. In the visual editor, pick **Custom…** in the Format dropdown to enter a combined format.
+
 ### Hiding
 
 The `hide_if` option can be used to hide an entity if its state or attribute value matches the specified criteria.

--- a/src/editor.test.ts
+++ b/src/editor.test.ts
@@ -183,6 +183,50 @@ describe('multiple-entity-row-editor', () => {
         });
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/385
+    describe('custom format', () => {
+        it('shows a pipeline format as Custom in the form data instead of clobbering it', () => {
+            setConfig({ entity: 'sensor.main', format: 'invert, precision3' });
+            expect((el as any)._mainFormData().format).toBe('__custom__');
+        });
+
+        it('keeps the real format when the form echoes the Custom sentinel back', () => {
+            setConfig({ entity: 'sensor.main', format: 'invert, precision3' });
+            (el as any)._mainValueChanged({
+                detail: { value: { entity: 'sensor.main', format: '__custom__' } },
+            });
+            expect(configs[0].format).toBe('invert, precision3');
+        });
+
+        it('picking Custom on a standard format preserves it and enters custom mode', () => {
+            setConfig({ entity: 'sensor.main', format: 'kilo' });
+            (el as any)._mainValueChanged({
+                detail: { value: { entity: 'sensor.main', format: '__custom__' } },
+            });
+            expect(configs[0].format).toBe('kilo');
+            expect((el as any)._isCustomFormat('main', 'kilo')).toBe(true);
+        });
+
+        it('picking a standard format leaves custom mode', () => {
+            setConfig({ entity: 'sensor.main', format: 'invert, precision3' });
+            (el as any)._mainValueChanged({
+                detail: { value: { entity: 'sensor.main', format: '__custom__' } },
+            });
+            (el as any)._mainValueChanged({
+                detail: { value: { entity: 'sensor.main', format: 'kilo' } },
+            });
+            const last = configs[configs.length - 1];
+            expect(last.format).toBe('kilo');
+            expect((el as any)._isCustomFormat('main', 'kilo')).toBe(false);
+        });
+
+        it('writes a per-entity custom format into that entity only', () => {
+            setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });
+            (el as any)._setAdditionalFormat(0, 'invert, kilo3');
+            expect(configs[0].entities).toEqual([{ entity: 'sensor.a', format: 'invert, kilo3' }]);
+        });
+    });
+
     describe('custom CSS block', () => {
         it('parses key: value lines into the styles object', () => {
             setConfig({ entity: 'sensor.main' });

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -10,7 +10,14 @@ import { keyed } from 'lit/directives/keyed.js';
 
 import { SECONDARY_INFO_VALUES } from './lib/constants';
 import { fireEvent, isObject } from './util';
-import { ADDITIONAL_TAB_SCHEMA, LABELS, MAIN_TAB_SCHEMA } from './editor_schemas';
+import {
+    ACTIONS_SCHEMA,
+    ADDITIONAL_TAB_SCHEMA,
+    CUSTOM_FORMAT,
+    KNOWN_FORMAT_VALUES,
+    LABELS,
+    MAIN_TAB_SCHEMA,
+} from './editor_schemas';
 import { EntityConfig, HASS, MultipleEntityRowConfig } from './types';
 
 type SecondaryMode = 'none' | 'text' | 'generic' | 'entity';
@@ -142,6 +149,7 @@ export class MultipleEntityRowEditor extends LitElement {
     declare _clipboardEntity?: EntityConfig;
     declare _stateIconRowsMain: StateIconRows;
     declare _stateIconRowsAdditional: Map<number, StateIconRows>;
+    declare _customFormatScopes: Set<string>;
 
     // Per-position stable keys for the entities tab list - lit needs these to swap tab contents
     // wholesale on reorder instead of mutating sibling tab contents in place.
@@ -159,6 +167,7 @@ export class MultipleEntityRowEditor extends LitElement {
             _clipboardEntity: { state: true },
             _stateIconRowsMain: { state: true },
             _stateIconRowsAdditional: { state: true },
+            _customFormatScopes: { state: true },
         };
     }
 
@@ -168,6 +177,7 @@ export class MultipleEntityRowEditor extends LitElement {
         this._entitiesExpanded = true;
         this._stateIconRowsMain = [];
         this._stateIconRowsAdditional = new Map();
+        this._customFormatScopes = new Set();
     }
 
     public setConfig(config: MultipleEntityRowConfig): void {
@@ -374,6 +384,63 @@ export class MultipleEntityRowEditor extends LitElement {
 
     private _computeLabel = (item: { name: string }): string => LABELS[item.name] ?? item.name;
 
+    // ── Custom format entry (see #385) ──────────────────────────────────
+    // The format dropdown ends with a "Custom…" sentinel. A scope is in custom mode when the
+    // user picked the sentinel, or when the config holds a format the dropdown doesn't know
+    // (comma pipelines like "invert, precision3", digit suffixes like "precision7") - without
+    // this, editing such a row through the form would silently clobber the YAML-only value.
+
+    private _isCustomFormat(scope: string, format?: string): boolean {
+        return this._customFormatScopes.has(scope) || (!!format && !KNOWN_FORMAT_VALUES.has(format));
+    }
+
+    private _setCustomFormatScope(scope: string, custom: boolean): void {
+        if (custom === this._customFormatScopes.has(scope)) return;
+        const next = new Set(this._customFormatScopes);
+        if (custom) next.add(scope);
+        else next.delete(scope);
+        this._customFormatScopes = next;
+    }
+
+    /** Swap a custom-mode format for the dropdown sentinel in the form's data. */
+    private _formatToForm<T extends { format?: string }>(scope: string, config: T): T {
+        return this._isCustomFormat(scope, config.format) ? { ...config, format: CUSTOM_FORMAT } : config;
+    }
+
+    /** Undo the sentinel on the way back out: picking "Custom…" must not overwrite the real
+     * format value - it only switches the scope into custom mode. */
+    private _formatFromForm<T extends { format?: string }>(scope: string, newConfig: T, oldFormat?: string): T {
+        if (newConfig.format === CUSTOM_FORMAT) {
+            this._setCustomFormatScope(scope, true);
+            const result = { ...newConfig };
+            if (oldFormat !== undefined) result.format = oldFormat;
+            else delete result.format;
+            return result;
+        }
+        this._setCustomFormatScope(scope, false);
+        return newConfig;
+    }
+
+    private _renderCustomFormatField(
+        scope: string,
+        format: string | undefined,
+        onChange: (format?: string) => void
+    ): TemplateResult | typeof nothing {
+        if (!this._isCustomFormat(scope, format)) return nothing;
+        return html`
+            <ha-form
+                .hass=${this.hass}
+                .data=${{ custom_format: format ?? '' }}
+                .schema=${[{ name: 'custom_format', selector: { text: {} } }]}
+                .computeLabel=${() => 'Custom format (e.g. invert, precision3)'}
+                @value-changed=${(ev: CustomEvent) => {
+                    const text = ((ev.detail.value as { custom_format?: string }).custom_format ?? '').trim();
+                    onChange(text || undefined);
+                }}
+            ></ha-form>
+        `;
+    }
+
     // ── Entities panel: Main (tab 0) + Additional (tabs 1+) ─────────────
 
     private _keyFor(index: number): string {
@@ -472,6 +539,17 @@ export class MultipleEntityRowEditor extends LitElement {
                     .hass=${this.hass}
                     .data=${this._mainFormData()}
                     .schema=${MAIN_TAB_SCHEMA}
+                    .computeLabel=${this._computeLabel}
+                    @value-changed=${this._mainValueChanged}
+                ></ha-form>
+                ${this._renderCustomFormatField('main', this._config?.format, (format) =>
+                    this._updateConfig({ format })
+                )}
+                <div class="section-label">Interactions</div>
+                <ha-form
+                    .hass=${this.hass}
+                    .data=${this._mainFormData()}
+                    .schema=${ACTIONS_SCHEMA}
                     .computeLabel=${this._computeLabel}
                     @value-changed=${this._mainValueChanged}
                 ></ha-form>
@@ -649,8 +727,19 @@ export class MultipleEntityRowEditor extends LitElement {
             <div class="child-editor">
                 <ha-form
                     .hass=${this.hass}
-                    .data=${unitToForm(entityConfig)}
+                    .data=${this._formatToForm(`sub-${additionalIndex}`, unitToForm(entityConfig))}
                     .schema=${ADDITIONAL_TAB_SCHEMA}
+                    .computeLabel=${this._computeLabel}
+                    @value-changed=${(ev: CustomEvent) => this._additionalValueChanged(ev, additionalIndex)}
+                ></ha-form>
+                ${this._renderCustomFormatField(`sub-${additionalIndex}`, entityConfig.format, (format) =>
+                    this._setAdditionalFormat(additionalIndex, format)
+                )}
+                <div class="section-label">Interactions</div>
+                <ha-form
+                    .hass=${this.hass}
+                    .data=${this._formatToForm(`sub-${additionalIndex}`, unitToForm(entityConfig))}
+                    .schema=${ACTIONS_SCHEMA}
                     .computeLabel=${this._computeLabel}
                     @value-changed=${(ev: CustomEvent) => this._additionalValueChanged(ev, additionalIndex)}
                 ></ha-form>
@@ -679,12 +768,13 @@ export class MultipleEntityRowEditor extends LitElement {
     /** Form data for the Main tab: seeds show_state's runtime default (ON) so the toggle reads
      * correctly for configs that don't set the key, and maps `unit: false` to its text form. */
     private _mainFormData(): MultipleEntityRowConfig {
-        return unitToForm({ show_state: true, ...this._config! });
+        return this._formatToForm('main', unitToForm({ show_state: true, ...this._config! }));
     }
 
     private _mainValueChanged = (ev: CustomEvent): void => {
         if (!this._config) return;
-        const newConfig = unitFromForm({ ...(ev.detail.value as MultipleEntityRowConfig) });
+        let newConfig = unitFromForm({ ...(ev.detail.value as MultipleEntityRowConfig) });
+        newConfig = this._formatFromForm('main', newConfig, this._config.format);
         // show_state: true is the seeded runtime default - strip the redundant key on the way
         // back out so it doesn't pollute the YAML.
         if (newConfig.show_state === true) delete newConfig.show_state;
@@ -694,9 +784,26 @@ export class MultipleEntityRowEditor extends LitElement {
     private _additionalValueChanged = (ev: CustomEvent, additionalIndex: number): void => {
         if (!this._config) return;
         const entities = [...(this._config.entities ?? [])];
-        entities[additionalIndex] = unitFromForm(ev.detail.value as EntityConfig);
+        const raw = entities[additionalIndex];
+        const oldFormat = isObject(raw) ? (raw as EntityConfig).format : undefined;
+        entities[additionalIndex] = this._formatFromForm(
+            `sub-${additionalIndex}`,
+            unitFromForm(ev.detail.value as EntityConfig),
+            oldFormat
+        );
         this._updateConfig({ entities });
     };
+
+    private _setAdditionalFormat(additionalIndex: number, format?: string): void {
+        if (!this._config) return;
+        const entities = [...(this._config.entities ?? [])];
+        const raw = entities[additionalIndex];
+        const conf: EntityConfig = typeof raw === 'string' ? { entity: raw } : { ...raw };
+        if (format) conf.format = format;
+        else delete conf.format;
+        entities[additionalIndex] = conf;
+        this._updateConfig({ entities });
+    }
 
     // ── Mutating handlers (Main is protected) ───────────────────────────
 
@@ -813,11 +920,16 @@ export class MultipleEntityRowEditor extends LitElement {
                     ? html`<div class="secondary-sub-form">
                           <ha-form
                               .hass=${this.hass}
-                              .data=${unitToForm(si as EntityConfig)}
+                              .data=${this._formatToForm('secondary', unitToForm(si as EntityConfig))}
                               .schema=${ADDITIONAL_TAB_SCHEMA}
                               .computeLabel=${this._computeLabel}
                               @value-changed=${this._secondaryEntityChanged}
                           ></ha-form>
+                          ${this._renderCustomFormatField('secondary', (si as EntityConfig).format, (format) =>
+                              this._updateConfig({
+                                  secondary_info: { ...(si as EntityConfig), format },
+                              })
+                          )}
                       </div>`
                     : nothing}
             </div>
@@ -855,7 +967,12 @@ export class MultipleEntityRowEditor extends LitElement {
     };
 
     private _secondaryEntityChanged = (ev: CustomEvent): void => {
-        this._updateConfig({ secondary_info: unitFromForm(ev.detail.value as EntityConfig) });
+        const oldFormat = isObject(this._config?.secondary_info)
+            ? (this._config!.secondary_info as EntityConfig).format
+            : undefined;
+        this._updateConfig({
+            secondary_info: this._formatFromForm('secondary', unitFromForm(ev.detail.value as EntityConfig), oldFormat),
+        });
     };
 
     // ── Helpers ─────────────────────────────────────────────────────────

--- a/src/editor_schemas.ts
+++ b/src/editor_schemas.ts
@@ -1,5 +1,9 @@
 // ha-form schemas for the visual editor. Adapted from the duczz/ha-multiple-entity-row fork.
 
+// Sentinel dropdown value for "enter the format string by hand" - covers comma-separated
+// pipelines (invert, precision3) and rarely-used digit suffixes not worth dropdown entries.
+export const CUSTOM_FORMAT = '__custom__';
+
 const FORMAT_OPTIONS = [
     { value: '', label: 'No format' },
     { value: 'brightness', label: 'Brightness (0-255 → %)' },
@@ -29,7 +33,10 @@ const FORMAT_OPTIONS = [
     { value: 'date', label: 'Timestamp: date' },
     { value: 'time', label: 'Timestamp: time' },
     { value: 'datetime', label: 'Timestamp: date + time' },
+    { value: CUSTOM_FORMAT, label: 'Custom…' },
 ];
+
+export const KNOWN_FORMAT_VALUES = new Set(FORMAT_OPTIONS.map((o) => o.value).filter((v) => v && v !== CUSTOM_FORMAT));
 
 // Tab "1" - the main entity. Writes to TOP-LEVEL config keys (config.entity, config.name, ...).
 export const MAIN_TAB_SCHEMA = [
@@ -72,18 +79,23 @@ export const MAIN_TAB_SCHEMA = [
     },
     { name: 'state_header', selector: { text: {} } },
     { name: 'image', selector: { text: {} } },
+    // format must stay the LAST entry: the editor renders the custom-format text box directly
+    // after this form, so it appears right under the format dropdown; the action selectors
+    // render as a separate form below it.
     { name: 'format', selector: { select: { mode: 'dropdown', options: FORMAT_OPTIONS } } },
-    // Row-level actions live in the Main tab, in the same format as the per-entity ones -
-    // a separate "Interactions" panel on screen alongside a tab's action selectors read as
-    // two competing blocks.
+];
+
+// Row-level actions live in the Main tab, in the same format as the per-entity ones - a
+// separate "Interactions" panel on screen alongside a tab's action selectors read as two
+// competing blocks. Rendered as its own form so the custom-format box can sit between.
+export const ACTIONS_SCHEMA = [
     { name: 'tap_action', selector: { ui_action: { default_action: 'more-info' } } },
     { name: 'hold_action', selector: { ui_action: { default_action: 'none' } } },
     { name: 'double_tap_action', selector: { ui_action: { default_action: 'none' } } },
 ];
 
-// Tabs "2".."N" - additional entities. Writes to config.entities[i-1]. Also reused for the
-// secondary-info entity form, where the action selectors are inert (secondary info has no
-// pointer handlers) - harmless.
+// Additional-entity tabs. Writes to config.entities[i-1]. Also reused for the secondary-info
+// entity form (which gets no ACTIONS_SCHEMA - secondary info has no pointer handlers).
 export const ADDITIONAL_TAB_SCHEMA = [
     { name: 'entity', selector: { entity: {} } },
     {
@@ -109,10 +121,8 @@ export const ADDITIONAL_TAB_SCHEMA = [
         ],
     },
     { name: 'hide_unavailable', selector: { boolean: {} } },
+    // Last for the same reason as MAIN_TAB_SCHEMA - the custom-format box renders right after.
     { name: 'format', selector: { select: { mode: 'dropdown', options: FORMAT_OPTIONS } } },
-    { name: 'tap_action', selector: { ui_action: { default_action: 'more-info' } } },
-    { name: 'hold_action', selector: { ui_action: { default_action: 'none' } } },
-    { name: 'double_tap_action', selector: { ui_action: { default_action: 'none' } } },
 ];
 
 export const LABELS: Record<string, string> = {

--- a/src/entity.js
+++ b/src/entity.js
@@ -55,6 +55,94 @@ const matchDigitSuffixFormat = (format) => {
 const isIncompleteDigitSuffixFormat = (format) =>
     DIGIT_SUFFIX_PREFIXES.some((prefix) => format?.startsWith(prefix)) && !matchDigitSuffixFormat(format);
 
+// Numeric formats can be combined comma-separated (`format: invert, precision3` - see #385).
+// Only value-transforming numeric segments compose: the raw number threads through every
+// segment and gets locale-formatted exactly once at the end, so a segment never re-parses
+// another segment's formatted output (which would break on locale separators like "1,234.5").
+// Duration, timestamp and string formats don't participate - they produce display strings, not
+// numbers, so anything else in a comma list falls through to the normal single-format handling.
+const PIPELINE_SEGMENT =
+    /^(brightness|percent|invert|position|celsius_to_fahrenheit|fahrenheit_to_celsius|kilo\d*|mega\d*|milli\d*|precision\d+)$/;
+
+const splitFormat = (format) =>
+    typeof format === 'string'
+        ? format
+              .split(',')
+              .map((segment) => segment.trim())
+              .filter(Boolean)
+        : [];
+
+const formatPipeline = (segments, rawValue, unit, locale) => {
+    let value = parseFloat(rawValue);
+    // Display precision: an explicit precisionN (or kilo3-style digit suffix) always wins;
+    // otherwise the last segment's own default applies (bare kilo's 2-decimal cap, etc.);
+    // with neither, the source value's decimal digits are preserved (see #304).
+    let digits = decimalDigits(rawValue);
+    let maxDigits;
+    let explicit = false;
+    const defaultCap = (cap) => {
+        if (!explicit) {
+            digits = undefined;
+            maxDigits = cap;
+        }
+    };
+
+    for (const segment of segments) {
+        const match = DIGIT_SUFFIX_FORMAT.exec(segment);
+        if (match && match[1] === 'precision') {
+            digits = parseInt(match[2], 10);
+            maxDigits = undefined;
+            explicit = true;
+            continue;
+        }
+        if (match) {
+            value = value / { kilo: 1000, mega: 1000000, milli: 1 / 1000 }[match[1]];
+            if (match[2] !== undefined) {
+                digits = parseInt(match[2], 10);
+                maxDigits = undefined;
+                explicit = true;
+            } else {
+                defaultCap(2);
+            }
+            continue;
+        }
+        switch (segment) {
+            case 'brightness':
+                value = Math.round((value / 255) * 100);
+                unit = '%';
+                defaultCap(0);
+                break;
+            case 'percent':
+                value = value * 100;
+                unit = '%';
+                defaultCap(2);
+                break;
+            case 'invert':
+                value = -value;
+                break;
+            case 'position':
+                value = 100 - value;
+                break;
+            case 'celsius_to_fahrenheit':
+                value = value * 1.8 + 32;
+                defaultCap(0);
+                break;
+            case 'fahrenheit_to_celsius':
+                value = ((value - 32) * 5) / 9;
+                defaultCap(1);
+                break;
+        }
+    }
+
+    const options =
+        digits !== undefined
+            ? { minimumFractionDigits: digits, maximumFractionDigits: digits }
+            : maxDigits !== undefined
+            ? { maximumFractionDigits: maxDigits }
+            : undefined;
+    return `${formatNumber(value, locale, options)}${unit ? ` ${unit}` : ''}`;
+};
+
 // String-only transforms - operate on any value, including non-numeric text states (see #367).
 const STRING_FORMATS = ['upper', 'lower', 'capitalize', 'title'];
 const stringTransform = (format, value) => {
@@ -114,6 +202,18 @@ export const entityStateDisplay = (hass, stateObj, config) => {
             : config.attribute !== undefined
             ? config.unit
             : config.unit || stateObj.attributes.unit_of_measurement;
+
+    // Comma-separated numeric formats compose as a pipeline (see #385). Only kicks in when
+    // every segment is a known numeric transform - otherwise the whole string falls through to
+    // the single-format handling below, same as any other unrecognized format.
+    const segments = splitFormat(config.format);
+    if (segments.length > 1 && segments.every((segment) => PIPELINE_SEGMENT.test(segment))) {
+        const pipelineValue = value === undefined || value === null ? 0 : value;
+        if (!isNaN(parseFloat(pipelineValue)) && isFinite(pipelineValue)) {
+            return formatPipeline(segments, pipelineValue, unit, hass.locale);
+        }
+        return `${pipelineValue}${unit ? ` ${unit}` : ''}`;
+    }
 
     if (config.format && !isIncompleteDigitSuffixFormat(config.format)) {
         // A missing attribute (e.g. brightness/color_temp on a light that's off) is undefined,

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -214,6 +214,57 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(hass, stateObj, { format: 'precision2' })).toBe('not-a-number');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/385 - numeric formats
+    // compose comma-separated, threading the raw number and formatting once at the end.
+    describe('format pipelines', () => {
+        it('combines invert with an explicit precision', () => {
+            const stateObj = { state: '18.123456', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'invert, precision3' })).toBe('-18.123');
+        });
+
+        it('combines kilo with an explicit precision', () => {
+            const stateObj = { state: '1234.5', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'kilo, precision1' })).toBe('1.2');
+        });
+
+        it('applies an explicit precision regardless of segment order', () => {
+            const stateObj = { state: '1234.5', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'precision1, kilo' })).toBe('1.2');
+        });
+
+        it('uses the digit-suffix form inside a pipeline', () => {
+            const stateObj = { state: '1500', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'invert, kilo3' })).toBe('-1.500');
+        });
+
+        it('applies the last bare segment default without an explicit precision', () => {
+            const stateObj = { state: '1234.5678', attributes: {} };
+            // bare kilo's 2-decimal cap applies, as if kilo were used alone
+            expect(entityStateDisplay(hass, stateObj, { format: 'invert, kilo' })).toBe('-1.23');
+        });
+
+        it('preserves source decimals for sign-only pipelines', () => {
+            const stateObj = { state: '5.60', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'invert, position' })).toBe('105.60');
+        });
+
+        it('falls through when a segment is not a numeric transform', () => {
+            const stateObj = { state: '90', attributes: {} };
+            // duration cannot compose - the whole string is passed through untouched
+            expect(entityStateDisplay(hass, stateObj, { format: 'duration, precision1' })).toBe('90');
+        });
+
+        it('does not crash on a mid-typed pipeline segment', () => {
+            const stateObj = { state: '18.5', attributes: {} };
+            expect(() => entityStateDisplay(hass, stateObj, { format: 'invert, precision' })).not.toThrow();
+        });
+
+        it('leaves non-numeric values untouched in a pipeline', () => {
+            const stateObj = { state: 'on', attributes: {} };
+            expect(entityStateDisplay(hass, stateObj, { format: 'invert, precision2' })).toBe('on');
+        });
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/225 -
     // a missing attribute (e.g. brightness/color_temp on a light that's off) must render as a
     // sensible zero value, not the literal string "undefined".


### PR DESCRIPTION
## Summary
Comma-separated numeric formats now compose as a pipeline: `format: invert, precision3`, `kilo, precision1`, `invert, kilo3`. The raw number threads through every segment and is locale-formatted exactly once at the end. An explicit `precision<N>` controls decimals wherever it appears; otherwise the last segment's own default applies; otherwise source decimals are preserved. Only number-transforming formats compose — durations/timestamps/text transforms fall through unchanged.

The visual editor's Format dropdown gains a **Custom…** option revealing a free-text field, which also protects YAML-only format strings (pipelines, `precision7`) from being clobbered when the row is edited through the form.

Fixes #385.

## Test plan
- [x] `yarn build` (lint + type-check + 186 tests + webpack) passes; 14 new tests
- [x] Verified live in a local HA instance