### PR TITLE
Fix row staying blank when hass arrives after the setConfig render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.7.1
+
+**Fixed:**
+- Row could stay permanently blank when the first `hass` assignment landed in a later update batch than `setConfig` - the first-hass update was swallowed by the re-render gate (found while diagnosing #400; likely the mechanism behind the intermittent blank rows in #389)
+
 ## 4.7.0
 
 **Breaking:**

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -82,6 +82,18 @@ describe('multiple-entity-row', () => {
         expect(el.shadowRoot.innerHTML).toContain('hui-warning');
     });
 
+    // setConfig and the first hass assignment can land in separate update batches (found via
+    // #400, likely behind the intermittent blank rows in #389): the config-only update renders
+    // empty, and the first-hass update must then actually paint the row rather than being
+    // swallowed by the shouldUpdate gate.
+    it('renders when hass arrives in a later update batch than setConfig', async () => {
+        el.setConfig({ entity: 'sensor.main' });
+        await flushRender(el); // config-only update completes first - renders empty
+        el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+        await flushRender(el);
+        expect(el.shadowRoot.innerHTML).toContain('hui-generic-entity-row');
+    });
+
     it('renders the entity row once hass has the configured entity state', async () => {
         el.setConfig({ entity: 'sensor.main' });
         el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });

--- a/src/util.js
+++ b/src/util.js
@@ -80,8 +80,15 @@ export const hasConfigOrEntitiesChanged = (node, changedProps) => {
         return true;
     }
 
-    const oldHass = changedProps.get('_hass');
-    if (oldHass) {
+    if (changedProps.has('_hass')) {
+        const oldHass = changedProps.get('_hass');
+        // First hass assignment: if setConfig rendered in an earlier update batch (empty - no
+        // hass yet), this is the update that must actually paint the row. Returning false here
+        // left the row permanently blank until an unrelated config change (see #400 diagnosis;
+        // likely the mechanism behind intermittent blank rows in #389).
+        if (!oldHass) {
+            return true;
+        }
         if (HASS_FORMATTER_KEYS.some((key) => oldHass[key] !== node._hass[key])) {
             return true;
         }


### PR DESCRIPTION
## Summary
If the first `hass` assignment landed in a later update batch than `setConfig`, `hasConfigOrEntitiesChanged` had no previous hass to diff against and returned `false` — leaving the config-only (empty) render on screen until an unrelated config change forced an update. The first hass assignment now always renders.

Found while diagnosing #400; likely the mechanism behind the intermittent blank rows tracked in #389.

## Test plan
- [x] `yarn build` (lint + type-check + 158 tests + webpack) passes
- [x] Regression test uses the two-batch sequence and fails without the fix