### PR TITLE
Fix narrow-row clipping from unbreakable percent values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 4.7.1-beta.1
+## 4.7.1-beta.2
 
 **Fixed:**
+- Rows with `%` entities clipping on narrow/mobile screens instead of wrapping - regression from the 4.6.0 switch to HA-native formatting (#403)
 - Row could stay permanently blank when the first `hass` assignment landed in a later update batch than `setConfig` - the first-hass update was swallowed by the re-render gate (found while diagnosing #400; likely the mechanism behind the intermittent blank rows in #389)
 
 ## 4.7.0

--- a/src/entity.js
+++ b/src/entity.js
@@ -181,6 +181,13 @@ export const entityName = (stateObj, config) => {
     );
 };
 
+// HA's formatter attaches % directly to the value in most locales ('87.0%'), making the whole
+// token unbreakable - in this card's dense multi-entity rows that fixes the row's minimum width
+// and clips narrow (mobile) cards instead of wrapping like every spaced unit does (see #403).
+// A zero-width space (\u200b) before the % keeps HA's visual convention but restores the break
+// point that a spaced unit ('87.0 %') naturally has.
+const breakablePercent = (value) => (typeof value === 'string' ? value.replace(/(\d)%/, '$1\u200b%') : value);
+
 export const entityStateDisplay = (hass, stateObj, config) => {
     // hass.formatEntityState/formatEntityAttributeValue apply the user's own locale/number-
     // format/precision preferences the same way HA's own UI does. Requires HA 2024.4+ (declared
@@ -282,10 +289,10 @@ export const entityStateDisplay = (hass, stateObj, config) => {
     const modifiedStateObj = { ...stateObj, attributes: { ...stateObj.attributes, unit_of_measurement: unit } };
 
     if (config.attribute) {
-        return hass.formatEntityAttributeValue(modifiedStateObj, config.attribute);
+        return breakablePercent(hass.formatEntityAttributeValue(modifiedStateObj, config.attribute));
     }
 
-    return hass.formatEntityState(modifiedStateObj);
+    return breakablePercent(hass.formatEntityState(modifiedStateObj));
 };
 
 export const entityStyles = (config) =>

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -261,6 +261,21 @@ describe('entityStateDisplay', () => {
     // See https://developers.home-assistant.io/docs/frontend/data#entity-state-formatting -
     // HA 2023.9+ exposes hass.formatEntityState/formatEntityAttributeValue, which apply the user's
     // own locale/precision preferences. Prefer these over our own reimplementation when present.
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/403 - HA formats percent
+    // as one unbreakable token ('87.0%'), which clips dense rows on narrow screens instead of
+    // wrapping. A zero-width space before the % restores the break point invisibly.
+    it('inserts a zero-width break before a formatter-attached percent sign', () => {
+        const pctHass = { ...hass, formatEntityState: vi.fn(() => '87.0%') };
+        const stateObj = { state: '87.0', attributes: { unit_of_measurement: '%' } };
+        expect(entityStateDisplay(pctHass, stateObj, {})).toBe('87.0\u200b%');
+    });
+
+    it('leaves spaced units without a zero-width space', () => {
+        const unitHass = { ...hass, formatEntityState: vi.fn(() => '1013.2 hPa') };
+        const stateObj = { state: '1013.2', attributes: { unit_of_measurement: 'hPa' } };
+        expect(entityStateDisplay(unitHass, stateObj, {})).toBe('1013.2 hPa');
+    });
+
     describe('official formatter delegation', () => {
         const officialHass = hass;
 


### PR DESCRIPTION
## Summary
HA's formatter attaches `%` directly to the value in most locales (`87.0%`), removing the wrap opportunity the pre-4.6.0 formatter's `87.0 %` had — one unbreakable token sets the whole row's minimum width and clips narrow (mobile) cards. A zero-width space before the `%` renders identically but wraps like a spaced unit.

Root-caused by bisecting released bundles (4.5.1 / 4.6.0 / 4.7.1) against a reproduction of the reporter's row in the local HA testbed.

Fixes #403.

## Test plan
- [x] `yarn build` (lint + type-check + 160 tests + webpack) passes; 2 new tests
- [x] Verified live: at narrow widths `%` values wrap exactly like 4.5.1; normal widths render unchanged