### PR TITLE
Fix four small display/action bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.7.1-beta.3
+
+**Fixed:**
+- `format:` timestamp options (`time`, `datetime`, ...) were silently ignored on the `last-changed`/`last-updated` attributes (#221, #305)
+- `default:` on a hidden/missing entity now resolves its header like a visible entity (friendly-name fallback) instead of requiring an explicit `name:` (#302)
+- `confirmation:` on `tap_action` now gates `toggle: true` toggles instead of being bypassed (#265)
+- A `name: false` entity (and the header-less main state) now aligns its value with headered siblings instead of floating centered (#281)
+
 ## 4.7.1-beta.2
 
 **Fixed:**

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ class MultipleEntityRow extends LitElement {
         if (hideIf(this.stateObj, this.config, this._hass)) {
             if (this.config.default) {
                 return html`<div class="state entity" style="${entityStyles(this.config)}">
-                    ${this.config.state_header && html`<span>${this.config.state_header}</span>`}
+                    ${this.renderMainHeader()}
                     <div>${this.config.default}</div>
                 </div>`;
             }
@@ -176,7 +176,7 @@ class MultipleEntityRow extends LitElement {
             @touchcancel="${stopBubble}"
             @contextmenu="${stopBubble}"
         >
-            ${this.config.state_header && html`<span>${this.config.state_header}</span>`}
+            ${this.renderMainHeader()}
             <div>${this.renderValue(this.stateObj, this.config)}</div>
         </div>`;
     }
@@ -184,8 +184,11 @@ class MultipleEntityRow extends LitElement {
     renderEntity(stateObj, config, index) {
         if (!stateObj || hideIf(stateObj, config, this._hass)) {
             if (config.default) {
+                // Same header resolution as a visible entity (friendly-name fallback etc., see
+                // #302) - except when the entity is missing entirely, where only an explicit
+                // name can label it.
                 return html`<div class="entity" style="${entityStyles(config)}">
-                    <span>${config.name}</span>
+                    <span>${stateObj ? entityName(stateObj, config) : config.name}</span>
                     <div>${config.default}</div>
                 </div>`;
             }
@@ -205,7 +208,7 @@ class MultipleEntityRow extends LitElement {
             @touchcancel="${stopBubble}"
             @contextmenu="${stopBubble}"
         >
-            <span>${entityName(stateObj, config)}</span>
+            <span>${entityName(stateObj, config) ?? this.headerPlaceholder()}</span>
             <div>
                 ${config.icon || isObject(config.state_icon)
                     ? this.renderIcon(stateObj, config)
@@ -214,19 +217,37 @@ class MultipleEntityRow extends LitElement {
         </div>`;
     }
 
+    // Main-state counterpart of headerPlaceholder(): render the state_header, or reserve the
+    // header line when sub-entities render headers so the main value stays level with theirs.
+    renderMainHeader() {
+        const header = this.config.state_header ?? this.headerPlaceholder();
+        return header ? html`<span>${header}</span>` : null;
+    }
+
+    // An empty header span collapses to zero height, so a name:false entity's value floats
+    // vertically centered while its headered siblings' values sit below their headers (see
+    // #281). Reserve the header line with an nbsp - but only when some sibling actually renders
+    // a header, so all-headerless rows keep their compact centered layout.
+    headerPlaceholder() {
+        const anyHeader =
+            this.config.state_header !== undefined ||
+            this.entities.some((entity) => entity.name !== false && (entity.name || entity.entity));
+        return anyHeader ? '\u00a0' : null;
+    }
+
     renderValue(stateObj, config) {
         if (config.toggle === true) {
-            return html`<ha-entity-toggle .stateObj="${stateObj}" .hass="${this._hass}"></ha-entity-toggle>`;
+            return this.renderToggle(stateObj, config);
         }
-        if (config.attribute && [LAST_CHANGED, LAST_UPDATED].includes(config.attribute)) {
-            return html`<ha-relative-time
-                .hass=${this._hass}
-                .datetime=${stateObj[config.attribute?.replace('-', '_')]}
-                capitalize
-            ></ha-relative-time>`;
-        }
+        const isLastChangedAttr = config.attribute && [LAST_CHANGED, LAST_UPDATED].includes(config.attribute);
+        // A configured timestamp format wins over the default relative-time widget for the
+        // last-changed/last-updated pseudo-attributes - previously it was silently ignored
+        // (see #221, #305). Those live on the state object itself (with underscores), not in
+        // attributes, hence the mapped lookup.
         if (config.format && TIMESTAMP_FORMATS.includes(config.format)) {
-            const value = config.attribute
+            const value = isLastChangedAttr
+                ? stateObj[config.attribute.replace('-', '_')]
+                : config.attribute
                 ? stateObj.attributes[config.attribute] ?? stateObj[config.attribute]
                 : stateObj.state;
             const timestamp = new Date(value);
@@ -240,7 +261,44 @@ class MultipleEntityRow extends LitElement {
                 capitalize
             ></hui-timestamp-display>`;
         }
+        if (isLastChangedAttr) {
+            return html`<ha-relative-time
+                .hass=${this._hass}
+                .datetime=${stateObj[config.attribute.replace('-', '_')]}
+                capitalize
+            ></ha-relative-time>`;
+        }
         return entityStateDisplay(this._hass, stateObj, config);
+    }
+
+    // ha-entity-toggle performs the toggle on its own tap, bypassing our action dispatch - so a
+    // configured confirmation never ran (see #265). When tap_action carries a confirmation,
+    // intercept the interaction ahead of the toggle (capture phase), ask, and forward the toggle
+    // through HA ourselves only on OK.
+    renderToggle(stateObj, config) {
+        const confirmation = config.tap_action?.confirmation;
+        if (!confirmation) {
+            return html`<ha-entity-toggle .stateObj="${stateObj}" .hass="${this._hass}"></ha-entity-toggle>`;
+        }
+        const confirmToggle = {
+            handleEvent: (ev) => {
+                ev.stopPropagation();
+                ev.preventDefault();
+                const exempt =
+                    isObject(confirmation) &&
+                    confirmation.exemptions?.some((exemption) => exemption.user === this._hass.user?.id);
+                const text =
+                    (isObject(confirmation) && confirmation.text) ||
+                    `Are you sure you want to toggle ${entityName(stateObj, config) ?? stateObj.entity_id}?`;
+                if (exempt || confirm(text)) {
+                    this._hass.callService('homeassistant', 'toggle', { entity_id: stateObj.entity_id });
+                }
+            },
+            capture: true,
+        };
+        return html`<span @click=${confirmToggle}>
+            <ha-entity-toggle .stateObj="${stateObj}" .hass="${this._hass}"></ha-entity-toggle>
+        </span>`;
     }
 
     renderIcon(stateObj, config) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -15,6 +15,7 @@ const buildHass = (states = {}) => ({
     localize: vi.fn((key) => `localized:${key}`),
     formatEntityState: vi.fn((stateObj) => stateObj.state),
     formatEntityAttributeValue: vi.fn((stateObj, attribute) => `${stateObj.attributes[attribute] ?? ''}`),
+    callService: vi.fn(),
 });
 
 describe('multiple-entity-row', () => {
@@ -109,6 +110,136 @@ describe('multiple-entity-row', () => {
         });
         expect(el.entities).toHaveLength(1);
         expect(el.entities[0].stateObj.entity_id).toBe('sensor.a');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/221 and #305 - a timestamp
+    // format on the last-changed/last-updated pseudo-attributes was silently ignored in favor of
+    // the relative-time widget.
+    describe('last-changed formatting', () => {
+        const hassWith = (extra = {}) =>
+            buildHass({
+                'sensor.main': {
+                    entity_id: 'sensor.main',
+                    state: 'on',
+                    attributes: {},
+                    last_changed: '2026-07-17T14:30:00+00:00',
+                    ...extra,
+                },
+            });
+
+        it('renders relative time by default for attribute last-changed', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.main', attribute: 'last-changed' }] });
+            el.hass = hassWith();
+            await flushRender(el);
+            expect(el.shadowRoot.innerHTML).toContain('ha-relative-time');
+        });
+
+        it('honors a timestamp format on attribute last-changed', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.main', attribute: 'last-changed', format: 'time' }],
+            });
+            el.hass = hassWith();
+            await flushRender(el);
+            expect(el.shadowRoot.innerHTML).toContain('hui-timestamp-display');
+            expect(el.shadowRoot.innerHTML).not.toContain('ha-relative-time');
+        });
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/302 - the default-value
+    // branch must resolve the header like a visible entity, not require an explicit name.
+    it('falls back to the friendly name for a hidden entity showing its default', async () => {
+        el.setConfig({
+            entity: 'sensor.main',
+            entities: [{ entity: 'sensor.a', hide_if: 'off', default: 'n/a' }],
+        });
+        el.hass = buildHass({
+            'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+            'sensor.a': { entity_id: 'sensor.a', state: 'off', attributes: { friendly_name: 'Alpha' } },
+        });
+        await flushRender(el);
+        expect(el.shadowRoot.innerHTML).toContain('Alpha');
+        expect(el.shadowRoot.innerHTML).toContain('n/a');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/265 - a confirmation on
+    // tap_action must gate the toggle instead of being bypassed by ha-entity-toggle.
+    describe('toggle confirmation', () => {
+        const toggleConfig = (tap_action) => ({
+            entity: 'sensor.main',
+            entities: [{ entity: 'switch.a', toggle: true, tap_action }],
+        });
+        const toggleHass = () =>
+            buildHass({
+                'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                'switch.a': { entity_id: 'switch.a', state: 'off', attributes: {} },
+            });
+
+        it('toggles via HA only after the user confirms', async () => {
+            vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+            el.setConfig(toggleConfig({ action: 'toggle', confirmation: { text: 'Sure?' } }));
+            el.hass = toggleHass();
+            await flushRender(el);
+            el.shadowRoot.querySelector('ha-entity-toggle').parentElement.click();
+            expect(confirm).toHaveBeenCalledWith('Sure?');
+            expect(el._hass.callService).toHaveBeenCalledWith('homeassistant', 'toggle', { entity_id: 'switch.a' });
+            vi.unstubAllGlobals();
+        });
+
+        it('does not toggle when the user cancels', async () => {
+            vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+            el.setConfig(toggleConfig({ action: 'toggle', confirmation: true }));
+            el.hass = toggleHass();
+            await flushRender(el);
+            el.shadowRoot.querySelector('ha-entity-toggle').parentElement.click();
+            expect(confirm).toHaveBeenCalled();
+            expect(el._hass.callService).not.toHaveBeenCalled();
+            vi.unstubAllGlobals();
+        });
+
+        it('renders a bare toggle when no confirmation is configured', async () => {
+            el.setConfig(toggleConfig({ action: 'toggle' }));
+            el.hass = toggleHass();
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('ha-entity-toggle').parentElement.tagName).not.toBe('SPAN');
+        });
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/281 - a name:false entity
+    // (and the header-less main state) reserves the header line so values align with headered
+    // siblings; an all-headerless row stays compact with no reserved line.
+    describe('header placeholder', () => {
+        const twoEntityHass = () =>
+            buildHass({
+                'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                'sensor.a': { entity_id: 'sensor.a', state: '1', attributes: { friendly_name: 'Alpha' } },
+                'sensor.b': { entity_id: 'sensor.b', state: '2', attributes: {} },
+            });
+
+        it('reserves the header line for name:false when a sibling has a header', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.a' }, { entity: 'sensor.b', name: false }],
+            });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(true);
+        });
+
+        it('inserts no placeholder when nothing renders a header', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [
+                    { entity: 'sensor.a', name: false },
+                    { entity: 'sensor.b', name: false },
+                ],
+            });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
+        });
     });
 
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/384


### PR DESCRIPTION
## Summary
- **#221/#305** — `format:` timestamp options (`time`, `datetime`, …) now apply to the `last-changed`/`last-updated` attributes instead of being silently ignored in favor of the relative-time widget.
- **#302** — `default:` on a hidden/missing entity resolves its header like a visible entity (friendly-name fallback) instead of requiring an explicit `name:`.
- **#265** — `confirmation:` on `tap_action` now gates `toggle: true`: intercepted ahead of `ha-entity-toggle`, honoring `text:` and user exemptions.
- **#281** — `name: false` entities (and the header-less main state) reserve the header line when a sibling renders one, so values stay aligned; all-headerless rows keep their compact layout.

Fixes #221, #305, #302, #265, #281.

## Test plan
- [x] `yarn build` (lint + type-check + 168 tests + webpack) passes; 8 new tests, verified to fail without the fixes
- [x] All four verified live in a local HA instance