### PR TITLE
Fix unit override ignored on attribute display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.7.1-beta.4
+
+**Fixed:**
+- `unit:` overrides (including `unit: false`) were ignored when displaying an attribute - regression from the 4.6.0 switch to HA-native formatting (#408)
+
 ## 4.7.1-beta.3
 
 **Fixed:**

--- a/src/entity.js
+++ b/src/entity.js
@@ -289,6 +289,15 @@ export const entityStateDisplay = (hass, stateObj, config) => {
     const modifiedStateObj = { ...stateObj, attributes: { ...stateObj.attributes, unit_of_measurement: unit } };
 
     if (config.attribute) {
+        // An explicit unit override (string or false) can't ride through
+        // formatEntityAttributeValue: unlike the state formatter, it ignores the entity's
+        // unit_of_measurement and derives the unit from HA's own attribute metadata (see #408).
+        // When the user configured unit:, format the value ourselves like pre-4.6.0 did.
+        if (config.unit !== undefined) {
+            const displayValue =
+                value === undefined || value === null ? '' : isNaN(value) ? value : formatNumber(value, hass.locale);
+            return `${displayValue}${unit ? ` ${unit}` : ''}`;
+        }
         return breakablePercent(hass.formatEntityAttributeValue(modifiedStateObj, config.attribute));
     }
 

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -276,6 +276,27 @@ describe('entityStateDisplay', () => {
         expect(entityStateDisplay(unitHass, stateObj, {})).toBe('1013.2 hPa');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/408 - the attribute
+    // formatter ignores entity-level unit_of_measurement, so explicit unit overrides must be
+    // formatted by the card itself.
+    describe('attribute unit overrides', () => {
+        const stateObj = { state: 'heat', attributes: { current_temperature: 22.5 } };
+
+        it('suppresses the unit with unit: false', () => {
+            expect(entityStateDisplay(hass, stateObj, { attribute: 'current_temperature', unit: false })).toBe('22.5');
+        });
+
+        it('applies a custom unit string', () => {
+            expect(entityStateDisplay(hass, stateObj, { attribute: 'current_temperature', unit: 'K' })).toBe('22.5 K');
+        });
+
+        it('still delegates to the attribute formatter without a unit override', () => {
+            expect(entityStateDisplay(hass, stateObj, { attribute: 'current_temperature' })).toBe(
+                'official-attr:current_temperature'
+            );
+        });
+    });
+
     describe('official formatter delegation', () => {
         const officialHass = hass;
 

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -122,6 +122,22 @@ describe('hideIf', () => {
         it('stays visible when the referenced entity does not exist', () => {
             expect(hideIf({ state: 'off' }, { hide_if: { entity: 'switch.missing', value: 'off' } }, hass)).toBe(false);
         });
+
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/406 - unavailable and
+        // unknown are ordinary state strings for hide_if matching, and they're distinct: sensors
+        // alternate between them, so the list form is the way to cover both.
+        it('matches unavailable and unknown like any other state value', () => {
+            const unavailableHass = { states: { 'sensor.ref': { state: 'unavailable', attributes: {} } } };
+            const unknownHass = { states: { 'sensor.ref': { state: 'unknown', attributes: {} } } };
+            const config = { hide_if: { entity: 'sensor.ref', value: 'unavailable' } };
+            expect(hideIf({ state: '5' }, config, unavailableHass)).toBe(true);
+            // a single value does NOT match the other special state...
+            expect(hideIf({ state: '5' }, config, unknownHass)).toBe(false);
+            // ...but the list form covers both
+            const listConfig = { hide_if: { entity: 'sensor.ref', value: ['unavailable', 'unknown'] } };
+            expect(hideIf({ state: '5' }, listConfig, unavailableHass)).toBe(true);
+            expect(hideIf({ state: '5' }, listConfig, unknownHass)).toBe(true);
+        });
     });
 });
 


### PR DESCRIPTION
## Summary
`formatEntityAttributeValue` ignores entity-level `unit_of_measurement` — unlike the state formatter — so `unit: false` and custom unit strings were silently discarded on attribute rows (regression from 4.6.0's formatter delegation). With an explicit `unit:` configured, the card formats the value directly like pre-4.6.0; the default path keeps full HA formatting.

Also adds regression tests for #406 documenting that `unavailable`/`unknown` are ordinary, distinct state strings for `hide_if` matching (list form covers both).

Fixes #408.

## Test plan
- [x] `yarn build` (lint + type-check + 172 tests + webpack) passes; 3 fix tests verified to fail without the change
- [x] Verified live in a local HA instance (`unit: false`, custom unit, and default formatting on a climate attribute)