### PR TITLE
Add server-side Jinja templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.8.0
+
+**Added:**
+- Jinja templating, rendered server-side by Home Assistant and updated live as referenced entities change. Supported in `name`, `icon`, `icon_color`, `secondary_info` text, `hide_if` (string form or `hide_if.template`), and a new `template:` option that replaces the displayed value; each template gets an `entity` variable holding the owning entity id (#409, #35, #249, #278, #247, #254, #269, #270)
+- Templated configs open directly in the code editor - the visual editor can't round-trip Jinja safely
+
 ## 4.7.1
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The above configuration can be managed in the Configuration -> Dashboards -> Res
 
 This card produces an `entity-row` and must therefore be configured as an entity in an [entities](https://www.home-assistant.io/lovelace/entities/) card.
 
-A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, digit-suffixed formats like `precision5`) are YAML-only.
+A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, digit-suffixed formats like `precision5`, [templates](#templating)) are YAML-only — a config containing templates opens directly in the code editor.
 
 | Name              | Type          | Default                             | Description                                      |
 | ----------------- | ------------- | ----------------------------------- | ------------------------------------------------ |
@@ -64,6 +64,7 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | hide_if           | object/any    | _[Hiding](#hiding)_                 | Hide the state value if criteria match           |
 | styles            | object        |                                     | Add custom CSS styles to the state element       |
 | format            | string        | _[Formatting](#formatting)_         | Format main state/attribute value                |
+| template          | string        | _[Templating](#templating)_         | Replace the state value with a template result   |
 |                   |
 | entities          | list          | _[Entity Objects](#entity-objects)_ | Additional entity IDs or entity object(s)        |
 | secondary_info    | string/object | _[Secondary Info](#secondary-info)_ | Custom `secondary_info` entity                   |
@@ -98,6 +99,7 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | hide_if           | object/any  | _[Hiding](#hiding)_         | Hide entity if its value matches specified value or criteria       |
 | styles            | object      |                             | Add custom CSS styles to the entity element                        |
 | format            | string      | _[Formatting](#formatting)_ | Format entity value                                                |
+| template          | string      | _[Templating](#templating)_ | Replace the entity value with a template result                    |
 | tap_action        | object      | _[Actions](#actions)_       | Custom entity tap action                                           |
 | hold_action       | object      | _[Actions](#actions)_       | Custom entity hold action                                          |
 | double_tap_action | object      | _[Actions](#actions)_       | Custom entity double-tap action                                    |
@@ -128,6 +130,7 @@ an object containing configuration options listed below, or any of the default s
 | hide_unavailable | bool        | `false`                     | Hide secondary info if its entity is unavailable         |
 | hide_if          | object/any  | _[Hiding](#hiding)_         | Hide secondary info if its value matches given criteria  |
 | format           | string      | _[Formatting](#formatting)_ | Format secondary info value                              |
+| template         | string      | _[Templating](#templating)_ | Replace the secondary info value with a template result  |
 
 ### Actions
 
@@ -208,6 +211,7 @@ or as an object with one or more of the options listed below.
 | value     | list/any | Hidden if value matches specified value or any value in a list  |
 | entity    | string   | Evaluate the criteria against this entity instead of its own    |
 | attribute | string   | Evaluate the criteria against this attribute's value            |
+| template  | string   | Hidden if the [template](#templating) renders true              |
 
 For example, only show the alarm exit-state sensor while the alarm is armed:
 
@@ -223,6 +227,36 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
 ```
 
 `hide_if` and `hide_unavailable` at the top level hide the main entity's state value (the row itself stays visible); `default` is shown in its place when set.
+
+### Templating
+
+Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated automatically whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template:
+
+- `name` (main row, additional entities, secondary info)
+- `secondary_info` as a plain string
+- `icon` and `icon_color`
+- `template` — replaces the displayed state value entirely
+- `hide_if` as a plain string, or `hide_if.template` — hides when the template renders `true`/`yes`/`on`/`1` (other `hide_if` criteria are ignored alongside a template)
+
+The variable `entity` holds the owning entity's id inside each template, so snippets stay portable across entities: `{{ states(entity) }}`.
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: sensor.next_ferry
+  name: "Next ferry {{ state_attr(entity, 'time') }}"
+  icon_color: "{{ 'red' if states('sensor.travel_time') | float(0) > 30 else 'green' }}"
+  hide_if: "{{ is_state('binary_sensor.ferry_service', 'off') }}"
+  entities:
+    - entity: sensor.travel_time
+      name: Drive
+      template: "{{ states(entity) | round(0) }} min"
+```
+
+Notes:
+
+- A `template` result is displayed verbatim — do rounding and formatting in the template itself (`format` is ignored). An explicit `unit` is appended. Ignored for `toggle: true` entities.
+- While a template's first result loads, the field renders blank. A template error also renders blank and logs a warning to the browser console.
+- Templated rows are YAML-only: the visual editor switches to the code editor when the config contains templates.
 
 ### Icon styling
 

--- a/README.md
+++ b/README.md
@@ -230,21 +230,12 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
 
 ### Templating
 
-Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated automatically whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template:
-
-- `name` (main row, additional entities, secondary info)
-- `secondary_info` as a plain string
-- `icon` and `icon_color`
-- `template` — replaces the displayed state value entirely
-- `hide_if` as a plain string, or `hide_if.template` — hides when the template renders `true`/`yes`/`on`/`1` (other `hide_if` criteria are ignored alongside a template)
-
-The variable `entity` holds the owning entity's id inside each template, so snippets stay portable across entities: `{{ states(entity) }}`.
+Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `secondary_info` text, `hide_if`, and a `template` option that replaces the displayed value entirely. The `entity` variable holds the owning entity's id.
 
 ```yaml
 - type: custom:multiple-entity-row
   entity: sensor.next_ferry
   name: "Next ferry {{ state_attr(entity, 'time') }}"
-  icon_color: "{{ 'red' if states('sensor.travel_time') | float(0) > 30 else 'green' }}"
   hide_if: "{{ is_state('binary_sensor.ferry_service', 'off') }}"
   entities:
     - entity: sensor.travel_time
@@ -252,11 +243,7 @@ The variable `entity` holds the owning entity's id inside each template, so snip
       template: "{{ states(entity) | round(0) }} min"
 ```
 
-Notes:
-
-- A `template` result is displayed verbatim — do rounding and formatting in the template itself (`format` is ignored). An explicit `unit` is appended. Ignored for `toggle: true` entities.
-- While a template's first result loads, the field renders blank. A template error also renders blank and logs a warning to the browser console.
-- Templated rows are YAML-only: the visual editor switches to the code editor when the config contains templates.
+See **[docs/templating.md](docs/templating.md)** for the full documentation: supported options, value-template semantics, hide conditions, loading/error behavior, and more examples. Templated rows are YAML-only — the visual editor switches to the code editor when a config contains templates.
 
 ### Icon styling
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1,0 +1,115 @@
+# Templating
+
+Since 4.8.0, display options accept Jinja **templates**. Templates are rendered by Home
+Assistant server-side — the same engine as automations and the Developer Tools template
+editor, with every HA template function and filter available — and results update live
+whenever the entities a template references change.
+
+Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template;
+there is no separate `*_template` key.
+
+## Supported options
+
+| Option           | Where                                    | Behavior                                              |
+| ---------------- | ---------------------------------------- | ----------------------------------------------------- |
+| `name`           | main row, additional entities, secondary | Result replaces the displayed name                    |
+| `secondary_info` | as a plain string                        | Result replaces the secondary text                    |
+| `icon`           | main row, additional entities            | Result is used as the icon (`mdi:...`)                |
+| `icon_color`     | main row, additional entities            | Result is used as the CSS color                       |
+| `template`       | main row, additional entities, secondary | Result replaces the displayed state value entirely    |
+| `hide_if`        | as a plain string, or `hide_if.template` | Hides when the result renders true                    |
+
+## The `entity` variable
+
+Inside each template, `entity` holds the id of the entity that owns the option (the row's
+main entity for row-level options, the sub-entity for per-entity options). This keeps
+snippets portable — the same template works after a copy/paste onto another entity:
+
+```yaml
+entities:
+  - entity: sensor.bedroom_temperature
+    template: "{{ states(entity) | round(1) }}"
+  - entity: sensor.kitchen_temperature
+    template: "{{ states(entity) | round(1) }}"
+```
+
+## Value templates (`template:`)
+
+`template:` replaces the displayed state value with the rendered result, shown verbatim:
+
+- `format:` is ignored — do rounding, scaling and text transforms in the template itself.
+- An explicit `unit:` is appended; the entity's own unit is not.
+- Ignored for `toggle: true` entities (the toggle owns that slot).
+- Non-string results are displayed sensibly: numbers as-is, lists/dicts as JSON.
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: sensor.washing_machine
+  entities:
+    # Substitution text instead of a raw state
+    - entity: sensor.washer_status
+      name: Status
+      template: >-
+        {{ 'No data' if is_state(entity, 'unavailable') else states(entity) | title }}
+    # Math across entities
+    - entity: sensor.power_usage
+      name: Cost/h
+      template: "{{ (states(entity) | float(0) * states('sensor.kwh_price') | float(0)) | round(2) }}"
+      unit: €
+    # Custom date format
+    - entity: sensor.next_collection
+      name: Pickup
+      template: "{{ as_timestamp(states(entity)) | timestamp_custom('%d-%m') }}"
+```
+
+## Conditional hiding (`hide_if` templates)
+
+A `hide_if` template hides its entity (or the main state, at row level) when the result
+renders to `true`, `yes`, `on` or `1` — native boolean results and strings both work,
+matching HA's own template-condition rules. Other `hide_if` criteria (`value`, `above`,
+`below`) are ignored when a template is present; put the whole condition in the template.
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: alarm_control_panel.home
+  entities:
+    # Condition on another entity's attribute (not possible with plain hide_if)
+    - entity: sensor.exit_delay
+      hide_if: "{{ state_attr('alarm_control_panel.home', 'arm_state') != 'arming' }}"
+    # Object form, e.g. alongside per-entity options
+    - entity: sensor.battery
+      hide_if:
+        template: "{{ states(entity) | float(100) > 20 }}"
+```
+
+Unlike `hide_if.entity`, a template can reference any number of entities — HA tracks them
+all and re-evaluates when any of them change.
+
+## Names, icons and colors
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: sensor.next_ferry
+  name: "Next ferry {{ state_attr(entity, 'time') }}"
+  icon_color: "{{ 'red' if states('sensor.travel_time') | float(0) > 30 else 'green' }}"
+  secondary_info: "updated {{ relative_time(states.sensor.next_ferry.last_updated) }} ago"
+  entities:
+    - entity: binary_sensor.ferry_docked
+      icon: "{{ 'mdi:ferry' if is_state(entity, 'on') else 'mdi:waves' }}"
+      name: Dock
+```
+
+## Behavior details
+
+- **While loading**: a template's field renders blank until its first result arrives
+  (typically well under a second) — never the raw Jinja source. A pending `hide_if`
+  renders visible; a pending `icon` shows the entity's own icon.
+- **Errors**: an erroring template renders blank and logs one warning per distinct error
+  to the browser console. Test templates in **Developer Tools → Template** first.
+- **Editor**: templated rows are YAML-only. Opening one in the visual editor shows
+  "Config is not supported" and drops to the code editor — round-tripping Jinja through
+  the form fields could corrupt it. Remove the templates and the visual editor works
+  again.
+- **Cost**: each distinct (template, entity) pair is one websocket subscription,
+  established while the row is on screen and torn down when it leaves. A handful per row
+  is fine; hundreds across a dashboard will add connection chatter.

--- a/src/editor.test.ts
+++ b/src/editor.test.ts
@@ -36,6 +36,19 @@ describe('multiple-entity-row-editor', () => {
         expect(customElements.get('multiple-entity-row-editor')).toBeDefined();
     });
 
+    // Templated configs are YAML-only: setConfig throws so HA's element editor falls back to
+    // its code editor instead of letting ha-form mangle the Jinja strings.
+    it('throws on a templated config to force the YAML editor', () => {
+        expect(() => setConfig({ entity: 'sensor.main', name: '{{ x }}' })).toThrow(/code \(YAML\) editor/);
+        expect(() =>
+            setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.a', hide_if: { template: '{% if x %}true{% endif %}' } }],
+            })
+        ).toThrow();
+        expect(() => setConfig({ entity: 'sensor.main', name: 'plain' })).not.toThrow();
+    });
+
     it('clamps the selected tab when entities shrink below it', () => {
         setConfig({ entity: 'sensor.main', entities: ['sensor.a', 'sensor.b'] });
         (el as any)._selectedTab = 2;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -10,6 +10,7 @@ import { keyed } from 'lit/directives/keyed.js';
 
 import { SECONDARY_INFO_VALUES } from './lib/constants';
 import { fireEvent, isObject } from './util';
+import { configHasTemplates } from './templates';
 import {
     ACTIONS_SCHEMA,
     ADDITIONAL_TAB_SCHEMA,
@@ -181,6 +182,11 @@ export class MultipleEntityRowEditor extends LitElement {
     }
 
     public setConfig(config: MultipleEntityRowConfig): void {
+        // Templated configs are YAML-only: round-tripping Jinja strings through ha-form risks
+        // mangling them. Throwing here makes HA's element editor fall back to its code editor.
+        if (configHasTemplates(config)) {
+            throw new Error('This row uses templates - edit it in the code (YAML) editor.');
+        }
         this._config = config;
         const maxAdditionalTab = config.entities?.length ?? 0;
         if (this._selectedTab > maxAdditionalTab) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
 import { checkEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
 import { fireEvent, getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
+import { hasTemplate, resolveTemplateFields, templateDisplay, TemplateSubscriptions } from './templates';
 import { style } from './styles';
 import './editor';
 
@@ -38,7 +39,26 @@ class MultipleEntityRow extends LitElement {
             _hass: Object,
             config: Object,
             stateObj: Object,
+            _templateResults: Object,
         };
+    }
+
+    constructor() {
+        super();
+        this._templateResults = new Map();
+        this._templates = new TemplateSubscriptions((results) => {
+            this._templateResults = results;
+        });
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._templates.connect();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._templates.disconnect();
     }
 
     setConfig(config) {
@@ -68,6 +88,7 @@ class MultipleEntityRow extends LitElement {
             name: config.name === false ? ' ' : config.name,
             format: config.format ?? config.time_format,
         };
+        this._templates.setConfig(this.config);
     }
 
     shouldUpdate(changedProps) {
@@ -76,6 +97,7 @@ class MultipleEntityRow extends LitElement {
 
     set hass(hass) {
         this._hass = hass;
+        this._templates.setHass(hass);
 
         if (hass && this.config) {
             this.stateObj = hass.states[this.config.entity];
@@ -96,14 +118,23 @@ class MultipleEntityRow extends LitElement {
         return style(css);
     }
 
+    // A copy of `config` (row-level, sub-entity or secondary_info object) with any templated
+    // fields swapped for their current subscription results - identity when nothing is
+    // templated. Resolution happens here at render time, so downstream display logic only ever
+    // sees plain values.
+    _resolved(config) {
+        return resolveTemplateFields(config, this._templateResults, config.entity ?? this.config.entity);
+    }
+
     render() {
         if (!this._hass || !this.config) return html``;
         if (!this.stateObj) return this.renderWarning();
 
+        const config = this._resolved(this.config);
         // A state_icon match overrides the main row's icon by injecting it into the config
         // handed to hui-generic-entity-row, which owns the main icon rendering (see #197).
-        const mainStateIcon = stateIcon(this.stateObj, this.config);
-        const rowConfig = mainStateIcon ? { ...this.config, icon: mainStateIcon } : this.config;
+        const mainStateIcon = stateIcon(this.stateObj, config);
+        const rowConfig = mainStateIcon ? { ...config, icon: mainStateIcon } : config;
 
         // catchInteraction: true tells hui-generic-entity-row not to attach its own tap/hold/
         // double-tap gesture detection to our slotted content. That detection is otherwise bound
@@ -113,7 +144,7 @@ class MultipleEntityRow extends LitElement {
         // entities gets its own tap/hold/double-tap handling in renderMainEntity/renderEntity
         // instead, correctly scoped to its own action config (see #338, #202).
         return html`<hui-generic-entity-row
-            style="${iconColorCss(this.config.icon_color)}"
+            style="${iconColorCss(config.icon_color)}"
             .hass="${this._hass}"
             .config="${rowConfig}"
             .secondaryText="${this.renderSecondaryInfo()}"
@@ -132,28 +163,32 @@ class MultipleEntityRow extends LitElement {
     }
 
     renderSecondaryInfo() {
-        if (
-            !this.config.secondary_info ||
-            hasGenericSecondaryInfo(this.config.secondary_info) ||
-            hideIf(this.info, this.config.secondary_info, this._hass)
-        ) {
+        const secondaryInfo = this.config.secondary_info;
+        if (!secondaryInfo || hasGenericSecondaryInfo(secondaryInfo)) {
             return null;
         }
-        if (typeof this.config.secondary_info === 'string') {
-            return html`${this.config.secondary_info}`;
+        if (typeof secondaryInfo === 'string') {
+            return html`${hasTemplate(secondaryInfo)
+                ? templateDisplay(this._templateResults, secondaryInfo, this.config.entity)
+                : secondaryInfo}`;
         }
-        const name = entityName(this.info, this.config.secondary_info);
-        return html`${name} ${this.renderValue(this.info, this.config.secondary_info)}`;
+        const config = this._resolved(secondaryInfo);
+        if (hideIf(this.info, config, this._hass)) {
+            return null;
+        }
+        const name = entityName(this.info, config);
+        return html`${name} ${this.renderValue(this.info, config)}`;
     }
 
     renderMainEntity() {
         if (this.config.show_state === false) {
             return null;
         }
+        const config = this._resolved(this.config);
         // Top-level hide_if/hide_unavailable hide the main state slot, symmetrical to per-entity
         // behavior - previously they were silently ignored on the main entity (see #227). The row
         // itself (name, icon, sub-entities) stays visible.
-        if (hideIf(this.stateObj, this.config, this._hass)) {
+        if (hideIf(this.stateObj, config, this._hass)) {
             if (this.config.default) {
                 return html`<div class="state entity" style="${entityStyles(this.config)}">
                     ${this.renderMainHeader()}
@@ -177,11 +212,12 @@ class MultipleEntityRow extends LitElement {
             @contextmenu="${stopBubble}"
         >
             ${this.renderMainHeader()}
-            <div>${this.renderValue(this.stateObj, this.config)}</div>
+            <div>${this.renderValue(this.stateObj, config)}</div>
         </div>`;
     }
 
     renderEntity(stateObj, config, index) {
+        config = this._resolved(config);
         if (!stateObj || hideIf(stateObj, config, this._hass)) {
             if (config.default) {
                 // Same header resolution as a visible entity (friendly-name fallback etc., see
@@ -238,6 +274,14 @@ class MultipleEntityRow extends LitElement {
     renderValue(stateObj, config) {
         if (config.toggle === true) {
             return this.renderToggle(stateObj, config);
+        }
+        // A value template replaces the displayed state entirely with its rendered result
+        // (already resolved by _resolved; a still-raw template renders blank rather than leaking
+        // Jinja source). Only an explicit unit is appended - format is deliberately skipped,
+        // since rounding/formatting belong in the template itself.
+        if (config.template !== undefined) {
+            const value = hasTemplate(config.template) ? '' : config.template;
+            return `${value}${config.unit ? ` ${config.unit}` : ''}`;
         }
         const isLastChangedAttr = config.attribute && [LAST_CHANGED, LAST_UPDATED].includes(config.attribute);
         // A configured timestamp format wins over the default relative-time widget for the

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -405,4 +405,107 @@ describe('multiple-entity-row', () => {
             expect(bubbled).not.toHaveBeenCalled();
         });
     });
+
+    // 4.8.0 templating: supported config strings containing {{ }} render server-side via a
+    // render_template websocket subscription (see #409 and the module comment in templates.ts).
+    describe('templating', () => {
+        let connection;
+
+        const buildConnection = () => {
+            const subs = [];
+            return {
+                subs,
+                subscribeMessage: vi.fn((callback, message) => {
+                    const sub = { callback, message, unsub: vi.fn(() => Promise.resolve()) };
+                    subs.push(sub);
+                    return Promise.resolve(sub.unsub);
+                }),
+            };
+        };
+
+        const hassWith = (states) => ({ ...buildHass(states), connection });
+
+        const states = () => ({
+            'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+            'sensor.a': { entity_id: 'sensor.a', state: '7', attributes: {} },
+        });
+
+        beforeEach(() => {
+            connection = buildConnection();
+        });
+
+        it('subscribes for templated fields and re-renders when a result is pushed', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', name: '{{ x }}' }] });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            expect(connection.subscribeMessage).toHaveBeenCalledTimes(1);
+            expect(connection.subs[0].message).toEqual({
+                type: 'render_template',
+                template: '{{ x }}',
+                variables: { entity: 'sensor.a' },
+                report_errors: true,
+            });
+            // Pending renders blank - never the raw Jinja source.
+            expect(el.shadowRoot.innerHTML).not.toContain('{{');
+
+            connection.subs[0].callback({ result: 'Wind' });
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === 'Wind')).toBe(true);
+        });
+
+        it('hides and unhides an entity as its hide_if template verdict changes', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', hide_if: '{{ hide }}' }] });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            // Pending verdict renders visible.
+            expect(el.shadowRoot.querySelectorAll('.entity:not(.state)')).toHaveLength(1);
+
+            connection.subs[0].callback({ result: true });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelectorAll('.entity:not(.state)')).toHaveLength(0);
+
+            connection.subs[0].callback({ result: false });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelectorAll('.entity:not(.state)')).toHaveLength(1);
+        });
+
+        it('renders a value template result verbatim with the configured unit', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.a', name: 'A', template: '{{ v }}', unit: 'km' }],
+            });
+            el.hass = hassWith(states());
+            connection.subs[0].callback({ result: 12.5 });
+            await flushRender(el);
+            const value = el.shadowRoot.querySelector('.entity:not(.state) div');
+            expect(value.textContent.trim()).toBe('12.5 km');
+        });
+
+        it('resolves a templated main name into the generic row config', async () => {
+            el.setConfig({ entity: 'sensor.main', name: '{{ n }}' });
+            el.hass = hassWith(states());
+            connection.subs[0].callback({ result: 'Row Name' });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('hui-generic-entity-row').config.name).toBe('Row Name');
+        });
+
+        it('renders a templated secondary_info string', async () => {
+            el.setConfig({ entity: 'sensor.main', secondary_info: '{{ s }}' });
+            el.hass = hassWith(states());
+            connection.subs[0].callback({ result: '5 min left' });
+            await flushRender(el);
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.secondaryText.values).toContain('5 min left');
+        });
+
+        it('unsubscribes when the element is disconnected', async () => {
+            el.setConfig({ entity: 'sensor.main', name: '{{ n }}' });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            el.remove();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(connection.subs[0].unsub).toHaveBeenCalled();
+        });
+    });
 });

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    collectTemplates,
+    configHasTemplates,
+    hasTemplate,
+    isTruthyResult,
+    resolveTemplateFields,
+    TemplateResults,
+    TemplateSubscriptions,
+} from './templates';
+
+const NAME_TEMPLATE = "{{ states('sensor.a') }} name";
+const HIDE_TEMPLATE = "{{ is_state('binary_sensor.away', 'on') }}";
+
+// Microtask/timer drain for the manager's promise-chained unsubscribes.
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+interface MockSub {
+    callback: (message: unknown) => void;
+    message: Record<string, any>;
+    unsub: ReturnType<typeof vi.fn>;
+}
+
+const buildConnection = () => {
+    const subs: MockSub[] = [];
+    return {
+        subs,
+        subscribeMessage: vi.fn((callback: (message: unknown) => void, message: Record<string, any>) => {
+            const sub: MockSub = { callback, message, unsub: vi.fn(() => Promise.resolve()) };
+            subs.push(sub);
+            return Promise.resolve(sub.unsub);
+        }),
+    };
+};
+
+/** Manager wired to a mock connection, already connected. Returns the latest notified results. */
+const buildManager = (config: Record<string, any>) => {
+    const connection = buildConnection();
+    let results: TemplateResults = new Map();
+    const manager = new TemplateSubscriptions((r) => (results = r));
+    manager.setConfig(config);
+    manager.setHass({ connection } as any);
+    manager.connect();
+    return { connection, manager, results: () => results };
+};
+
+describe('hasTemplate', () => {
+    it('detects {{ }} and {% %} in strings', () => {
+        expect(hasTemplate('{{ states("sensor.a") }}')).toBe(true);
+        expect(hasTemplate('{% if x %}y{% endif %}')).toBe(true);
+    });
+
+    it('is false for plain strings and non-strings', () => {
+        expect(hasTemplate('Living Room')).toBe(false);
+        expect(hasTemplate(false)).toBe(false);
+        expect(hasTemplate({ template: '{{ x }}' })).toBe(false);
+        expect(hasTemplate(undefined)).toBe(false);
+    });
+});
+
+describe('configHasTemplates', () => {
+    it('finds templates nested anywhere in the config', () => {
+        expect(configHasTemplates({ entity: 'sensor.a', entities: [{ name: '{{ x }}' }] })).toBe(true);
+        expect(configHasTemplates({ hide_if: { template: '{% if x %}true{% endif %}' } })).toBe(true);
+    });
+
+    it('is false for a template-free config', () => {
+        expect(configHasTemplates({ entity: 'sensor.a', entities: ['sensor.b', { name: 'plain' }] })).toBe(false);
+    });
+});
+
+describe('isTruthyResult', () => {
+    it('accepts native true, 1 and the HA condition strings', () => {
+        expect(isTruthyResult(true)).toBe(true);
+        expect(isTruthyResult(1)).toBe(true);
+        expect(isTruthyResult('true')).toBe(true);
+        expect(isTruthyResult(' On ')).toBe(true);
+        expect(isTruthyResult('YES')).toBe(true);
+        expect(isTruthyResult('1')).toBe(true);
+    });
+
+    it('rejects everything else, including pending results', () => {
+        expect(isTruthyResult(false)).toBe(false);
+        expect(isTruthyResult('false')).toBe(false);
+        expect(isTruthyResult('')).toBe(false);
+        expect(isTruthyResult(0)).toBe(false);
+        expect(isTruthyResult(undefined)).toBe(false);
+        expect(isTruthyResult(null)).toBe(false);
+    });
+});
+
+describe('collectTemplates', () => {
+    it('collects templated fields with their owning entity', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            name: NAME_TEMPLATE,
+            icon_color: '{{ "red" }}',
+            entities: ['sensor.plain', { entity: 'sensor.a', template: '{{ states(entity) }}' }, { name: 'static' }],
+            secondary_info: { entity: 'sensor.b', name: '{{ y }}' },
+        });
+        expect(requests).toEqual([
+            { template: NAME_TEMPLATE, entity: 'sensor.main' },
+            { template: '{{ "red" }}', entity: 'sensor.main' },
+            { template: '{{ y }}', entity: 'sensor.b' },
+            { template: '{{ states(entity) }}', entity: 'sensor.a' },
+        ]);
+    });
+
+    it('falls back to the main entity as owner for entity-less entries', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            entities: [{ attribute: 'battery', name: '{{ x }}' }],
+            secondary_info: '{{ z }}',
+        });
+        expect(requests).toEqual([
+            { template: '{{ z }}', entity: 'sensor.main' },
+            { template: '{{ x }}', entity: 'sensor.main' },
+        ]);
+    });
+
+    it('collects both hide_if template forms', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            hide_if: HIDE_TEMPLATE,
+            entities: [{ entity: 'sensor.a', hide_if: { template: '{{ q }}' } }],
+        });
+        expect(requests).toEqual([
+            { template: HIDE_TEMPLATE, entity: 'sensor.main' },
+            { template: '{{ q }}', entity: 'sensor.a' },
+        ]);
+    });
+});
+
+describe('resolveTemplateFields', () => {
+    const empty: TemplateResults = new Map();
+
+    it('returns the config unchanged (same identity) when nothing is templated', () => {
+        const config = { entity: 'sensor.a', name: 'plain' };
+        expect(resolveTemplateFields(config, empty, 'sensor.a')).toBe(config);
+    });
+
+    it('renders a pending name as a space, not the friendly-name fallback', () => {
+        const resolved = resolveTemplateFields({ entity: 'sensor.a', name: NAME_TEMPLATE }, empty, 'sensor.a');
+        expect(resolved.name).toBe(' ');
+    });
+
+    it('treats a pending icon as icon: true so the slot stays in icon mode', () => {
+        const resolved = resolveTemplateFields({ entity: 'sensor.a', icon: '{{ x }}' }, empty, 'sensor.a');
+        expect(resolved.icon).toBe(true);
+    });
+
+    it('clears a pending icon_color and value template', () => {
+        const resolved = resolveTemplateFields(
+            { entity: 'sensor.a', icon_color: '{{ x }}', template: '{{ y }}' },
+            empty,
+            'sensor.a'
+        );
+        expect(resolved.icon_color).toBe('');
+        expect(resolved.template).toBe('');
+    });
+
+    it('collapses a pending hide_if template to visible', () => {
+        const resolved = resolveTemplateFields({ entity: 'sensor.a', hide_if: HIDE_TEMPLATE }, empty, 'sensor.a');
+        expect(resolved.hide_if).toBe(false);
+    });
+
+    it('substitutes pushed results, stringifying non-string types', () => {
+        const config = {
+            entity: 'sensor.a',
+            name: '{{ n }}',
+            template: '{{ v }}',
+            icon: '{{ i }}',
+            hide_if: { template: '{{ h }}' },
+        };
+        const { connection, results } = buildManager(config);
+        connection.subs.forEach((sub) => {
+            const value = { '{{ n }}': 'Wind', '{{ v }}': 42, '{{ i }}': 'mdi:fan', '{{ h }}': true }[
+                sub.message.template as string
+            ];
+            sub.callback({ result: value });
+        });
+        const resolved = resolveTemplateFields(config, results(), 'sensor.a');
+        expect(resolved.name).toBe('Wind');
+        expect(resolved.template).toBe('42');
+        expect(resolved.icon).toBe('mdi:fan');
+        expect(resolved.hide_if).toBe(true);
+    });
+
+    it('stringifies list/dict results as JSON instead of [object Object]', () => {
+        const config = { entity: 'sensor.a', template: '{{ v }}' };
+        const { connection, results } = buildManager(config);
+        connection.subs[0].callback({ result: { a: 1 } });
+        expect(resolveTemplateFields(config, results(), 'sensor.a').template).toBe('{"a":1}');
+    });
+});
+
+describe('TemplateSubscriptions', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('subscribes with the render_template payload and owner entity variable', () => {
+        const { connection } = buildManager({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(1);
+        expect(connection.subs[0].message).toEqual({
+            type: 'render_template',
+            template: NAME_TEMPLATE,
+            variables: { entity: 'sensor.main' },
+            report_errors: true,
+        });
+    });
+
+    it('does not subscribe until the element is connected', () => {
+        const connection = buildConnection();
+        const manager = new TemplateSubscriptions(() => undefined);
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        manager.setHass({ connection } as any);
+        expect(connection.subscribeMessage).not.toHaveBeenCalled();
+        manager.connect();
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('tolerates a hass without a websocket connection', () => {
+        const manager = new TemplateSubscriptions(() => undefined);
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        manager.setHass({} as any);
+        expect(() => manager.connect()).not.toThrow();
+    });
+
+    it('subscribes once config, hass and connect have all arrived, in any order', () => {
+        const connection = buildConnection();
+        const manager = new TemplateSubscriptions(() => undefined);
+        manager.connect();
+        manager.setHass({ connection } as any);
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies with a fresh results map on each pushed result', () => {
+        const { connection, results } = buildManager({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        connection.subs[0].callback({ result: 'one' });
+        const first = results();
+        connection.subs[0].callback({ result: 'two' });
+        expect(results()).not.toBe(first); // new identity so Lit sees the property change
+        expect([...results().values()]).toEqual(['two']);
+    });
+
+    it('keeps unchanged subscriptions across a config change and drops removed ones', async () => {
+        const { connection, manager, results } = buildManager({
+            entity: 'sensor.main',
+            name: NAME_TEMPLATE,
+            icon_color: '{{ c }}',
+        });
+        connection.subs[1].callback({ result: 'red' });
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(2);
+
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        await tick();
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(2); // no resubscribe churn
+        expect(connection.subs[1].unsub).toHaveBeenCalled();
+        // The dropped template's result is gone from the next notified map.
+        connection.subs[0].callback({ result: 'name' });
+        expect([...results().values()]).toEqual(['name']);
+    });
+
+    it('unsubscribes on disconnect and resubscribes on reconnect', async () => {
+        const { connection, manager } = buildManager({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        manager.disconnect();
+        await tick();
+        expect(connection.subs[0].unsub).toHaveBeenCalled();
+
+        manager.connect();
+        expect(connection.subscribeMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores late events arriving after unsubscribe', async () => {
+        const notify = vi.fn();
+        const connection = buildConnection();
+        const manager = new TemplateSubscriptions(notify);
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        manager.setHass({ connection } as any);
+        manager.connect();
+        manager.disconnect();
+        await tick();
+        connection.subs[0].callback({ result: 'late' });
+        expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('renders an error event as a blank result and warns only on message change', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const { connection, results } = buildManager({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        connection.subs[0].callback({ error: 'boom', level: 'ERROR' });
+        connection.subs[0].callback({ error: 'boom', level: 'ERROR' });
+        expect([...results().values()]).toEqual(['']);
+        expect(warn).toHaveBeenCalledTimes(1);
+
+        connection.subs[0].callback({ result: 'recovered' });
+        expect([...results().values()]).toEqual(['recovered']);
+    });
+
+    it('survives a rejected subscribe without an unhandled rejection', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const connection = {
+            subscribeMessage: vi.fn(() => Promise.reject(new Error('no template integration'))),
+        };
+        const manager = new TemplateSubscriptions(() => undefined);
+        manager.setConfig({ entity: 'sensor.main', name: NAME_TEMPLATE });
+        manager.setHass({ connection } as any);
+        manager.connect();
+        await tick();
+        expect(warn).toHaveBeenCalledTimes(1);
+        manager.disconnect(); // unsub of the failed subscription is a no-op, not a crash
+        await tick();
+    });
+});

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,222 @@
+// Server-side Jinja templating via HA's render_template websocket subscription - the same API
+// the core markdown card and template dev tool use. Any supported config string containing
+// {{ or {% is treated as a template (see #409, #35, #249, #278, #247, #254, #269, #270).
+// HA tracks each template's entity dependencies itself and pushes a new result whenever they
+// change, so templated fields need no getEntityIds bookkeeping - updates arrive even for
+// entities the row doesn't otherwise watch.
+
+import { isObject } from './util';
+import { HASS, LooseObject } from './types';
+
+interface TemplateRequest {
+    template: string;
+    entity?: string;
+}
+
+// {result, listeners} on success; {error, level} events when report_errors is set.
+interface RenderTemplateMessage {
+    result?: unknown;
+    error?: string;
+    level?: string;
+}
+
+export type TemplateResults = Map<string, unknown>;
+
+export const hasTemplate = (value: unknown): value is string =>
+    typeof value === 'string' && (value.includes('{{') || value.includes('{%'));
+
+// Deep scan used by the editor: a template anywhere in the config forces YAML-only editing,
+// since round-tripping Jinja strings through ha-form risks mangling them.
+export const configHasTemplates = (value: unknown): boolean => {
+    if (hasTemplate(value)) return true;
+    if (Array.isArray(value)) return value.some(configHasTemplates);
+    if (isObject(value)) return Object.values(value as LooseObject).some(configHasTemplates);
+    return false;
+};
+
+// hide_if template: shorthand string form (hide_if: "{{ ... }}") or object form
+// (hide_if: {template: "{{ ... }}"}). The object form ignores other criteria - a template
+// subsumes value/below/above.
+const hideIfTemplate = (config: LooseObject): string | undefined => {
+    if (hasTemplate(config.hide_if)) return config.hide_if;
+    if (isObject(config.hide_if) && hasTemplate(config.hide_if.template)) return config.hide_if.template;
+    return undefined;
+};
+
+// render_template pushes native JSON types, not just strings: accept a real boolean result
+// ({{ is_state(...) }}) as well as the string forms HA's own template conditions treat as true.
+const TRUE_STRINGS = ['true', 'yes', 'on', '1'];
+export const isTruthyResult = (result: unknown): boolean =>
+    result === true ||
+    result === 1 ||
+    (typeof result === 'string' && TRUE_STRINGS.includes(result.trim().toLowerCase()));
+
+// Pending (undefined) and none results render blank - never the raw Jinja source.
+const displayResult = (result: unknown): string =>
+    result === undefined || result === null ? '' : typeof result === 'object' ? JSON.stringify(result) : String(result);
+
+// Results are keyed by (owner entity, template): the same template subscribed for two entities
+// gets different `entity` variables, so the results are distinct.
+const resultKey = (template: string, entity?: string): string => `${entity ?? ''}|${template}`;
+
+export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
+    const requests: TemplateRequest[] = [];
+    const add = (template: unknown, entity?: string): void => {
+        if (hasTemplate(template)) requests.push({ template, entity });
+    };
+    const collectEntry = (entry: LooseObject, owner?: string): void => {
+        add(entry.name, owner);
+        add(entry.icon, owner);
+        add(entry.icon_color, owner);
+        add(entry.template, owner);
+        add(hideIfTemplate(entry), owner);
+    };
+    const main = config.entity as string | undefined;
+    collectEntry(config, main);
+    if (typeof config.secondary_info === 'string') {
+        add(config.secondary_info, main);
+    } else if (isObject(config.secondary_info)) {
+        collectEntry(config.secondary_info, config.secondary_info.entity ?? main);
+    }
+    (config.entities as unknown[] | undefined)?.forEach((entry) => {
+        if (isObject(entry)) collectEntry(entry as LooseObject, (entry as LooseObject).entity ?? main);
+    });
+    return requests;
+};
+
+/** A copy of `config` with its templated fields replaced by their current results (identity
+ * when nothing is templated). `owner` must match the entity used at collect time. */
+export const resolveTemplateFields = <T extends LooseObject>(
+    config: T,
+    results: TemplateResults,
+    owner?: string
+): T => {
+    let resolved = config;
+    const patch = (key: string, value: unknown): void => {
+        if (resolved === config) resolved = { ...config };
+        (resolved as LooseObject)[key] = value;
+    };
+    const get = (template: string): unknown => results.get(resultKey(template, owner));
+
+    if (hasTemplate(config.name)) {
+        // An empty name would fall back to the entity's friendly name in entityName - a pending
+        // template must render blank instead of flashing the fallback, so pad to a space.
+        patch('name', displayResult(get(config.name)) || ' ');
+    }
+    if (hasTemplate(config.icon)) {
+        // While pending, behave like icon: true (the entity's own icon) so the slot doesn't
+        // flip between icon and value rendering when the result lands.
+        const result = get(config.icon);
+        patch('icon', result === undefined || result === null || result === '' ? true : String(result));
+    }
+    if (hasTemplate(config.icon_color)) {
+        const result = get(config.icon_color);
+        patch('icon_color', typeof result === 'string' ? result : '');
+    }
+    if (hasTemplate(config.template)) {
+        patch('template', displayResult(get(config.template)));
+    }
+    const hideTemplate = hideIfTemplate(config);
+    if (hideTemplate) {
+        // Collapse to the boolean verdict hideIf understands. Pending renders visible, matching
+        // hide_if.entity's missing-reference behavior.
+        patch('hide_if', isTruthyResult(get(hideTemplate)));
+    }
+    return resolved;
+};
+
+/** Current display string for a standalone template (e.g. a templated secondary_info string). */
+export const templateDisplay = (results: TemplateResults, template: string, entity?: string): string =>
+    displayResult(results.get(resultKey(template, entity)));
+
+type UnsubscribeFunc = () => Promise<void> | void;
+
+/** Owns the render_template subscriptions for one row element. Config, hass and DOM attachment
+ * arrive in any order (and repeatedly - the card editor calls setConfig per keystroke), so every
+ * entry point funnels into an idempotent sync() that reconciles active subscriptions with the
+ * wanted set. Subscriptions only run while the element is connected; home-assistant-js-websocket
+ * restores them itself across connection drops. */
+export class TemplateSubscriptions {
+    private hass?: HASS;
+    private connected = false;
+    private requests = new Map<string, TemplateRequest>();
+    private unsubs = new Map<string, Promise<UnsubscribeFunc | null>>();
+    private errors = new Map<string, string>();
+    private results: TemplateResults = new Map();
+    private notify: (results: TemplateResults) => void;
+
+    constructor(notify: (results: TemplateResults) => void) {
+        this.notify = notify;
+    }
+
+    setConfig(config: LooseObject): void {
+        this.requests = new Map(collectTemplates(config).map((req) => [resultKey(req.template, req.entity), req]));
+        this.sync();
+    }
+
+    setHass(hass?: HASS): void {
+        const hadConnection = !!this.hass?.connection;
+        this.hass = hass;
+        if (!hadConnection && hass?.connection) this.sync();
+    }
+
+    connect(): void {
+        this.connected = true;
+        this.sync();
+    }
+
+    disconnect(): void {
+        this.connected = false;
+        this.sync();
+    }
+
+    private sync(): void {
+        for (const [key, pending] of this.unsubs) {
+            if (this.connected && this.requests.has(key)) continue;
+            this.unsubs.delete(key);
+            // Results survive a disconnect (instant repaint on reattach) but not a config
+            // change that dropped the template.
+            if (!this.requests.has(key)) {
+                this.results.delete(key);
+                this.errors.delete(key);
+            }
+            pending.then((unsub) => unsub?.()).catch(() => undefined);
+        }
+        if (!this.connected || !this.hass?.connection) return;
+        for (const [key, request] of this.requests) {
+            if (!this.unsubs.has(key)) this.unsubs.set(key, this.subscribe(key, request));
+        }
+    }
+
+    private subscribe(key: string, request: TemplateRequest): Promise<UnsubscribeFunc | null> {
+        return this.hass!.connection!.subscribeMessage(
+            (message: RenderTemplateMessage) => this.onMessage(key, message),
+            {
+                type: 'render_template',
+                template: request.template,
+                variables: { entity: request.entity },
+                report_errors: true,
+            }
+        ).catch((err: unknown) => {
+            console.warn('multiple-entity-row: template subscription failed:', request.template, err);
+            return null;
+        });
+    }
+
+    private onMessage(key: string, message: RenderTemplateMessage): void {
+        if (!this.unsubs.has(key)) return; // late event after unsubscribe
+        if (message.error !== undefined) {
+            // Errors repeat on every dependency change - warn only when the message changes.
+            if (this.errors.get(key) !== message.error) {
+                this.errors.set(key, message.error);
+                console.warn('multiple-entity-row: template error:', message.error);
+            }
+            this.results.set(key, '');
+        } else {
+            this.errors.delete(key);
+            this.results.set(key, message.result);
+        }
+        // Fresh Map identity so Lit sees the reactive property change.
+        this.notify(new Map(this.results));
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,11 @@ export interface HassEntity {
     last_updated?: string;
 }
 
+export interface HassConnection {
+    subscribeMessage: <T>(callback: (message: T) => void, message: LooseObject) => Promise<() => Promise<void>>;
+    [key: string]: any;
+}
+
 export interface HASS {
     states: Record<string, HassEntity>;
     locale: { language: string; number_format?: string; time_format?: string; [key: string]: any };
@@ -20,6 +25,7 @@ export interface HASS {
     formatEntityAttributeValue?: (stateObj: HassEntity, attribute: string, value?: any) => string;
     formatEntityName?: (entityOrId: HassEntity | string, name?: string) => string;
     callService: (domain: string, service: string, data?: LooseObject) => Promise<any>;
+    connection?: HassConnection;
     [key: string]: any;
 }
 
@@ -46,10 +52,13 @@ export interface HideIfObject {
     value?: any | any[];
     entity?: string;
     attribute?: string;
+    template?: string;
 }
 
 interface EntityOptions {
     format?: string;
+    // Jinja template replacing the displayed state (rendered server-side; see templates.ts).
+    template?: string;
     attribute?: string;
     unit?: string | false;
     name?: string | false;

--- a/src/util.js
+++ b/src/util.js
@@ -25,6 +25,12 @@ export const hideIf = (stateObj, config, hass) => {
     if (config.hide_if === undefined) {
         return false;
     }
+    // A templated hide_if arrives here already collapsed to its boolean verdict (see
+    // resolveTemplateFields in templates.ts). Plain booleans were never meaningful here before
+    // (they can't equal a state string), so this branch is backward-safe.
+    if (typeof config.hide_if === 'boolean') {
+        return config.hide_if;
+    }
 
     let value;
     if (isObject(config.hide_if) && (config.hide_if.entity || config.hide_if.attribute)) {
@@ -77,6 +83,12 @@ const HASS_FORMATTER_KEYS = ['formatEntityName', 'formatEntityState', 'formatEnt
 
 export const hasConfigOrEntitiesChanged = (node, changedProps) => {
     if (changedProps.has('config')) {
+        return true;
+    }
+
+    // Template results arrive via our own render_template subscription push, not through a hass
+    // assignment, so they need their own re-render trigger (see templates.ts).
+    if (changedProps.has('_templateResults')) {
         return true;
     }
 

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -74,6 +74,13 @@ describe('hideIf', () => {
         expect(hideIf({ state: 'idle' }, { hide_if: ['off', 'idle'] })).toBe(true);
     });
 
+    // A templated hide_if reaches hideIf already collapsed to its boolean verdict (see
+    // resolveTemplateFields in templates.ts).
+    it('treats a boolean hide_if as a pre-resolved template verdict', () => {
+        expect(hideIf({ state: 'on' }, { hide_if: true })).toBe(true);
+        expect(hideIf({ state: 'on' }, { hide_if: false })).toBe(false);
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/227 -
     // hide_if must also work against an attribute value, not just the main state.
     it('checks against the configured attribute value', () => {


### PR DESCRIPTION
Templates (`{{ }}` / `{% %}`) are auto-detected in `name`, `icon`, `icon_color`, `secondary_info` text, `hide_if` (string form or `hide_if.template`), and a new `template:` option that replaces the displayed value. Rendered server-side via `render_template` websocket subscriptions with an `entity` variable, so results update live as referenced entities change — no client-side Jinja, no new dependencies. Full docs in [docs/templating.md](https://github.com/benct/lovelace-multiple-entity-row/blob/master/docs/templating.md).

Pending and error results render blank rather than leaking raw Jinja. Templated configs open directly in the code editor: the visual editor's `setConfig` throws and HA's element editor falls back to YAML (mechanism verified in the bundled `hui-element-editor`).

Refs #409, #35, #249, #278, #247, #254, #269, #270 — closures at the 4.8.0 final release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)