### PR TITLE
Fix unit override on state values with translated units (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Jinja templating, rendered server-side by Home Assistant and updated live as referenced entities change. Supported in `name`, `icon`, `icon_color`, `secondary_info` text, `hide_if` (string form or `hide_if.template`), and a new `template:` option that replaces the displayed value; each template gets an `entity` variable holding the owning entity id (#409, #35, #249, #278, #247, #254, #269, #270)
 - Templated configs open directly in the code editor - the visual editor can't round-trip Jinja safely
 
+**Fixed:**
+- `unit:` overrides (including `unit: false`) ignored on state values of entities whose integration ships translated units, e.g. Analytics Insights - the card now formats overridden values itself, keeping locale formatting and the display-precision setting (#413)
+
 ## 4.7.1
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ None of `kilo`/`mega`/`milli`/`invert`/`position` change the displayed unit — 
   unit: kW
 ```
 
+An explicit `unit:` (or `unit: false`) makes the card format the value itself instead of delegating to HA's state formatter — necessary because the formatter re-applies its own unit for integrations that translate units (e.g. Analytics Insights). HA's locale rules and the entity's display-precision setting still apply, but formatter renderings driven by the entity's own unit are lost: notably, `device_class: monetary` entities lose HA's currency styling (`$4.00`) under an override, so leave `unit` unset on currency entities.
+
 Numeric formats can be **combined** comma-separated — the value flows through each in turn and is formatted once at the end. An explicit `precision<N>` controls the decimals wherever it appears; otherwise the last format's own default applies:
 
 ```yaml

--- a/src/entity.js
+++ b/src/entity.js
@@ -288,6 +288,27 @@ export const entityStateDisplay = (hass, stateObj, config) => {
 
     const modifiedStateObj = { ...stateObj, attributes: { ...stateObj.attributes, unit_of_measurement: unit } };
 
+    // An explicit unit override can't reliably ride through formatEntityState either: when the
+    // entity registry entry has a translation_key and the integration ships a translated unit
+    // (e.g. analytics_insights), the formatter prefers that translation over the
+    // unit_of_measurement injected into modifiedStateObj (see #413). Format numeric values
+    // ourselves, replicating the formatter's own precision rule (registry display_precision,
+    // fixed decimals). Non-numeric values keep delegating - the formatter never appends a unit
+    // to those, so state translations are preserved and the override can't be beaten. Trade-off:
+    // device_class monetary entities lose HA's currency styling under an override (documented).
+    if (config.unit !== undefined && !config.attribute) {
+        if (!isNaN(parseFloat(value)) && isFinite(value)) {
+            const precision = hass.entities?.[stateObj.entity_id]?.display_precision;
+            const displayValue = formatNumber(
+                value,
+                hass.locale,
+                precision != null ? { minimumFractionDigits: precision, maximumFractionDigits: precision } : undefined
+            );
+            return `${displayValue}${unit ? ` ${unit}` : ''}`;
+        }
+        return `${hass.formatEntityState(stateObj)}${unit ? ` ${unit}` : ''}`;
+    }
+
     if (config.attribute) {
         // An explicit unit override (string or false) can't ride through
         // formatEntityAttributeValue: unlike the state formatter, it ignores the entity's

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -297,6 +297,56 @@ describe('entityStateDisplay', () => {
         });
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/413 - formatEntityState
+    // prefers an integration's translated unit (entity registry translation_key) over the
+    // unit_of_measurement injected into the cloned state object, so explicit unit overrides on
+    // the state value must be formatted by the card itself too. The mock reproduces the
+    // translated-unit behavior: it appends the integration unit regardless of the passed
+    // attributes.
+    describe('state unit overrides', () => {
+        const translatedHass = {
+            ...hass,
+            entities: {},
+            formatEntityState: vi.fn((stateObj) => `${stateObj.state} active installations`),
+        };
+        const stateObj = {
+            entity_id: 'sensor.analytics',
+            state: '4',
+            attributes: { unit_of_measurement: 'active installations', state_class: 'total' },
+        };
+
+        it('applies a custom unit string despite a translated unit', () => {
+            expect(entityStateDisplay(translatedHass, stateObj, { unit: 'installs' })).toBe('4 installs');
+        });
+
+        it('suppresses a translated unit with unit: false', () => {
+            expect(entityStateDisplay(translatedHass, stateObj, { unit: false })).toBe('4');
+        });
+
+        it('honors the registry display_precision setting', () => {
+            const precisionHass = {
+                ...translatedHass,
+                entities: { 'sensor.analytics': { display_precision: 2 } },
+            };
+            expect(entityStateDisplay(precisionHass, stateObj, { unit: 'installs' })).toBe('4.00 installs');
+        });
+
+        it('preserves source decimals when no display_precision is set', () => {
+            const decimalStateObj = { ...stateObj, state: '4.567' };
+            expect(entityStateDisplay(translatedHass, decimalStateObj, { unit: 'installs' })).toBe('4.567 installs');
+        });
+
+        it('delegates non-numeric values for state translation, then appends the unit', () => {
+            const textStateObj = { entity_id: 'sensor.mode', state: 'active', attributes: {} };
+            const textHass = { ...hass, formatEntityState: vi.fn(() => 'localized-active') };
+            expect(entityStateDisplay(textHass, textStateObj, { unit: 'mode' })).toBe('localized-active mode');
+        });
+
+        it('still delegates to formatEntityState without a unit override', () => {
+            expect(entityStateDisplay(translatedHass, stateObj, {})).toBe('4 active installations');
+        });
+    });
+
     describe('official formatter delegation', () => {
         const officialHass = hass;
 


### PR DESCRIPTION
HA's state formatter prefers an integration's translated unit (entity registry `translation_key`) over the `unit_of_measurement` injected into the cloned state object, so `unit:` overrides were ignored for integrations that translate units (e.g. Analytics Insights). Explicit `unit:`/`unit: false` now formats the value in the card, keeping locale formatting and the registry display-precision setting; non-numeric states still delegate to `formatEntityState` for state translations. Trade-off documented in the README: `device_class: monetary` currency styling is lost under an override.

Refs #413 — close on reporter confirmation of the beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)