### PR TITLE
Reserve the header line for blank names (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `unit:` overrides (including `unit: false`) ignored on state values of entities whose integration ships translated units, e.g. Analytics Insights - the card now formats overridden values itself, keeping locale formatting and the display-precision setting (#413)
 - Custom `width`/`justify-content` styling of `.entities-row` had no effect since 4.7.0: HA wrapped the row in shrink-to-fit boxes because the #338 fix set `catchInteraction`, which pinned the row to its content width (#411)
 - Clicking the name or header of a `toggle: true` entity did nothing since 4.7.0 - toggle entities were skipped when wiring gesture handling, leaving everything but the switch dead (#415)
+- Entities using `name: ' '` sat a line higher than their siblings since 4.7.1: the blank header collapsed to zero height while the main state reserved its line, misaligning toggles and values (#418)
 
 **Added:**
 - `wrap` option - reflow entities onto multiple lines instead of overflowing the card on narrow screens (#411)

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,15 @@ import './editor';
 // dispatch fires (see #338, #202, #188, #251).
 const stopBubble = (event) => event.stopPropagation();
 
+const NBSP = '\u00a0';
+
+// `name: ' '` is the long-standing idiom for "blank header, but keep the line". HTML collapses
+// that space, so the span ends up zero-height and the entity renders one line shorter than its
+// headered siblings - which since #281 includes the main state, whose placeholder is an nbsp and
+// does not collapse. Render any blank header as that same nbsp so both sides reserve a line and
+// stay level (see #418).
+const headerText = (text) => (typeof text === 'string' && text.trim() === '' ? NBSP : text);
+
 console.info(
     `%c MULTIPLE-ENTITY-ROW %c ${process.env.PACKAGE_VERSION} (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
     'color: cyan; background: black; font-weight: bold;',
@@ -232,7 +241,7 @@ class MultipleEntityRow extends LitElement {
                 // #302) - except when the entity is missing entirely, where only an explicit
                 // name can label it.
                 return html`<div class="entity" style="${entityStyles(config)}">
-                    <span>${stateObj ? entityName(stateObj, config) : config.name}</span>
+                    <span>${headerText(stateObj ? entityName(stateObj, config) : config.name)}</span>
                     <div>${config.default}</div>
                 </div>`;
             }
@@ -252,7 +261,7 @@ class MultipleEntityRow extends LitElement {
             @touchcancel="${stopBubble}"
             @contextmenu="${stopBubble}"
         >
-            <span>${entityName(stateObj, config) ?? this.headerPlaceholder()}</span>
+            <span>${headerText(entityName(stateObj, config)) ?? this.headerPlaceholder()}</span>
             <div>
                 ${config.icon || isObject(config.state_icon)
                     ? this.renderIcon(stateObj, config)
@@ -264,7 +273,7 @@ class MultipleEntityRow extends LitElement {
     // Main-state counterpart of headerPlaceholder(): render the state_header, or reserve the
     // header line when sub-entities render headers so the main value stays level with theirs.
     renderMainHeader() {
-        const header = this.config.state_header ?? this.headerPlaceholder();
+        const header = headerText(this.config.state_header) ?? this.headerPlaceholder();
         return header ? html`<span>${header}</span>` : null;
     }
 
@@ -276,7 +285,7 @@ class MultipleEntityRow extends LitElement {
         const anyHeader =
             this.config.state_header !== undefined ||
             this.entities.some((entity) => entity.name !== false && (entity.name || entity.entity));
-        return anyHeader ? '\u00a0' : null;
+        return anyHeader ? NBSP : null;
     }
 
     renderValue(stateObj, config) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -247,6 +247,42 @@ describe('multiple-entity-row', () => {
             const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
             expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
         });
+
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/418 - `name: ' '` is
+        // the idiom for a blank-but-present header. A literal space collapses to zero height, so
+        // that entity ended up a line shorter than the main state, whose #281 placeholder is a
+        // non-collapsing nbsp - the toggle/value misalignment reported against 4.7.1-beta.3.
+        it('reserves the header line for a whitespace-only name', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', name: ' ' }] });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            // both the sub-entity's blank header and the main state's placeholder reserve a line
+            expect(spans.filter((span) => span.textContent === '\u00a0')).toHaveLength(2);
+            expect(spans.some((span) => span.textContent === ' ')).toBe(false);
+        });
+
+        it('reserves the header line for a whitespace-only state_header', async () => {
+            el.setConfig({ entity: 'sensor.main', state_header: ' ', entities: [{ entity: 'sensor.a' }] });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(true);
+            expect(spans.some((span) => span.textContent === ' ')).toBe(false);
+        });
+
+        // The default-value branch renders its own header span (see #302).
+        it('reserves the header line for a whitespace-only name on a hidden entity', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.a', name: ' ', hide_if: '1', default: 'n/a' }],
+            });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(true);
+            expect(spans.some((span) => span.textContent === ' ')).toBe(false);
+        });
     });
 
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/384


### PR DESCRIPTION
`name: ' '` is the idiom for a blank-but-present header, but HTML collapses that space, so the span had zero height and the entity sat a line higher than its siblings. Since #281 the main state reserves its line with a non-collapsing nbsp, which made the mismatch visible — toggles and values drifting out of line from 4.7.1-beta.3 onwards.

Render any whitespace-only header as that same nbsp, covering sub-entities, the default-value branch and `state_header`.

Refs #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)