### PR TITLE
Follow HA's color API for entity icons (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.9.0
+
+**Breaking:**
+- Entity icons are now colored by state by default, matching Home Assistant's entities card since 2026.8. Set `color: none` on the row or entity to restore the previous look. Rows already using `state_color` or `icon_color` are unaffected (#416)
+
+**Added:**
+- `color` option on the row and on additional entities, following HA's icon color API: `state`, `none`, a theme color name (`red`, `deep-purple`, ...) or any CSS color. Templatable like `icon_color`. Works back to HA 2024.4; theme colors and `state` need 2026.8+ for the main row icon (#416)
+
+**Deprecated:**
+- `state_color` - still accepted and mapped to `color` (`true` → `state`, `false` → `none`), and no longer offered in the visual editor
+
 ## 4.8.0
 
 **Added:**

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | show_state        | bool          | `true`                              | Set to `false` to hide the main entity           |
 | show_state_first  | bool          | `false`                             | Show the main state before other entities        |
 | state_header      | string        |                                     | Show header text above the main entity state     |
-| state_color       | bool          | `false`                             | Enable colored icon when entity is active        |
+| color             | string        | `state`                             | `state`, `none`, a theme color or a CSS color    |
+| state_color       | bool          | _deprecated_                        | Superseded by `color`                            |
 | column            | bool          | `false`                             | Show entities in a column instead of a row       |
 | wrap              | bool          | `false`                             | Wrap onto multiple lines instead of overflowing  |
 | default           | string        |                                     | Display this value when the state is hidden      |
@@ -92,7 +93,8 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | unit              | string/bool | `unit_of_measurement`       | Override entity unit of measurement (or `false` to hide)           |
 | toggle            | bool        | `false`                     | Display a toggle if supported by domain                            |
 | icon              | string/bool | `false`                     | Display default or custom icon instead of state or attribute value |
-| state_color       | bool        | `false`                     | Enable colored icon when entity is active                          |
+| color             | string      | `state`                     | `state`, `none`, a theme color or a CSS color                      |
+| state_color       | bool        | _deprecated_                | Superseded by `color`                                              |
 | icon_color        | string      |                             | CSS color for the entity icon                                      |
 | state_icon        | object      |                             | Map of state value → icon override                                 |
 | default           | string      |                             | Display this value if the entity does not exist or is hidden       |
@@ -233,7 +235,7 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
 
 ### Templating
 
-Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `secondary_info` text, `hide_if`, and a `template` option that replaces the displayed value entirely. The `entity` variable holds the owning entity's id.
+Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `color`, `secondary_info` text, `hide_if`, and a `template` option that replaces the displayed value entirely. The `entity` variable holds the owning entity's id.
 
 ```yaml
 - type: custom:multiple-entity-row
@@ -250,7 +252,24 @@ See **[docs/templating.md](docs/templating.md)** for the full documentation: sup
 
 ### Icon styling
 
-`icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
+`color` follows Home Assistant's icon color option and accepts `state` (color by entity state), `none` (never color), a theme color name (`red`, `deep-purple`, `accent`), or any CSS color. It applies to the main row icon and to additional entities rendering an icon. The default is `state`, matching the entities card:
+
+```yaml
+- entity: light.kitchen
+  type: custom:multiple-entity-row
+  color: state
+  entities:
+    - entity: binary_sensor.back_door
+      icon: true
+      color: red
+    - entity: sensor.humidity
+      icon: true
+      color: none
+```
+
+Theme color names and `state` require Home Assistant 2026.8 or newer for the main row icon; on older versions use `icon_color` there. `state_color` is still accepted as a deprecated alias — `true` means `color: state`, `false` means `color: none`.
+
+`icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon **regardless of state**, which is the one thing `color` cannot express. Setting it also switches that entity's default to `color: none`, so the two do not fight; an explicit `color` still wins. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
 
 ```yaml
 - entity: binary_sensor.front_door

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@
 
 services:
   ha:
-    image: ghcr.io/home-assistant/home-assistant:stable
+    # Override to test against another HA release, e.g. HA_VERSION=beta (next month's release,
+    # useful for verifying frontend changes before they land) or a pinned tag like 2026.7.4.
+    image: ghcr.io/home-assistant/home-assistant:${HA_VERSION:-stable}
     container_name: mer-ha
     restart: unless-stopped
     ports:

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -16,6 +16,7 @@ there is no separate `*_template` key.
 | `secondary_info` | as a plain string                        | Result replaces the secondary text                    |
 | `icon`           | main row, additional entities            | Result is used as the icon (`mdi:...`)                |
 | `icon_color`     | main row, additional entities            | Result is used as the CSS color                       |
+| `color`          | main row, additional entities            | `state`, `none`, a theme color or a CSS color         |
 | `template`       | main row, additional entities, secondary | Result replaces the displayed state value entirely    |
 | `hide_if`        | as a plain string, or `hide_if.template` | Hides when the result renders true                    |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-entity-row",
-  "version": "4.9.0-alpha.1",
+  "version": "4.9.0-beta.1",
   "description": "Show multiple entity states, attributes and icons on entity rows in Home Assistant's Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-entity-row",
-  "version": "4.8.0",
+  "version": "4.9.0-alpha.1",
   "description": "Show multiple entity states, attributes and icons on entity rows in Home Assistant's Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { badgeColorProps, computeCssColor, resolveColor, rowColorConfig } from './color';
+
+describe('computeCssColor', () => {
+    it('maps theme color names to their CSS variable', () => {
+        expect(computeCssColor('red')).toBe('var(--red-color)');
+        expect(computeCssColor('deep-purple')).toBe('var(--deep-purple-color)');
+        expect(computeCssColor('primary-text')).toBe('var(--primary-text-color)');
+    });
+
+    it('passes any other CSS color through unchanged', () => {
+        expect(computeCssColor('#ff0000')).toBe('#ff0000');
+        expect(computeCssColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)');
+        expect(computeCssColor('var(--my-own-color)')).toBe('var(--my-own-color)');
+    });
+});
+
+// See https://github.com/benct/lovelace-multiple-entity-row/issues/416 - HA 2026.8 replaced the
+// boolean state_color with color ("state" | "none" | theme color | CSS color) and colors entity
+// rows by default. The card follows that default so its rows match built-in ones.
+describe('resolveColor', () => {
+    it('defaults to state coloring', () => {
+        expect(resolveColor({})).toEqual({ stateColor: true });
+    });
+
+    it('honors explicit state/none', () => {
+        expect(resolveColor({ color: 'state' })).toEqual({ stateColor: true });
+        expect(resolveColor({ color: 'none' })).toEqual({ stateColor: false });
+    });
+
+    it('computes custom colors', () => {
+        expect(resolveColor({ color: 'red' })).toEqual({ cssColor: 'var(--red-color)' });
+        expect(resolveColor({ color: '#abc' })).toEqual({ cssColor: '#abc' });
+    });
+
+    it('accepts the deprecated state_color as an alias', () => {
+        expect(resolveColor({ state_color: true })).toEqual({ stateColor: true });
+        expect(resolveColor({ state_color: false })).toEqual({ stateColor: false });
+    });
+
+    it('lets color win over state_color', () => {
+        expect(resolveColor({ color: 'none', state_color: true })).toEqual({ stateColor: false });
+    });
+
+    // An inline state color would override the CSS variables icon_color paints with, so a
+    // configured icon_color would otherwise vanish exactly when the entity is active.
+    it('does not default to state coloring when icon_color is configured', () => {
+        expect(resolveColor({ icon_color: 'red' })).toEqual({ stateColor: false });
+    });
+
+    it('still lets an explicit color win over icon_color', () => {
+        expect(resolveColor({ icon_color: 'red', color: 'state' })).toEqual({ stateColor: true });
+        expect(resolveColor({ icon_color: 'red', state_color: true })).toEqual({ stateColor: true });
+    });
+});
+
+describe('badgeColorProps', () => {
+    // Passing the literal "state" as `color` would be treated as a raw CSS color by pre-2026.8
+    // state-badges and render nothing, so state/none always travel as the legacy boolean.
+    it('expresses state/none as the legacy stateColor boolean', () => {
+        expect(badgeColorProps({ stateColor: true })).toEqual({ stateColor: true });
+        expect(badgeColorProps({ stateColor: false })).toEqual({ stateColor: false });
+    });
+
+    it('passes a computed custom color as color', () => {
+        expect(badgeColorProps({ cssColor: 'var(--red-color)' })).toEqual({ color: 'var(--red-color)' });
+    });
+});
+
+describe('rowColorConfig', () => {
+    it('uses config-shaped keys for hui-generic-entity-row', () => {
+        expect(rowColorConfig({ stateColor: true })).toEqual({ state_color: true });
+        expect(rowColorConfig({ cssColor: '#abc' })).toEqual({ color: '#abc' });
+    });
+});

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,0 +1,87 @@
+// Support for HA's `color` option (frontend PR #53151, HA 2026.8), which replaced the boolean
+// `state_color` with "state" | "none" | a theme color name | any CSS color.
+//
+// The card supports HA back to 2024.4, where state-badge's `color` property meant something else
+// entirely - a raw CSS color applied unconditionally, with no notion of "state"/"none". Rather
+// than sniff hass.config.version, resolveColor() maps a config value onto the state-badge
+// properties that behave correctly on BOTH sides. See applyColor() for that mapping.
+
+// Mirrors THEME_COLORS + YAML_ONLY_THEMES_COLORS in HA's src/common/color/compute-color.ts.
+const THEME_COLORS = new Set([
+    'primary',
+    'accent',
+    'red',
+    'pink',
+    'purple',
+    'deep-purple',
+    'indigo',
+    'blue',
+    'light-blue',
+    'cyan',
+    'teal',
+    'green',
+    'light-green',
+    'lime',
+    'yellow',
+    'amber',
+    'orange',
+    'deep-orange',
+    'brown',
+    'light-grey',
+    'grey',
+    'dark-grey',
+    'blue-grey',
+    'black',
+    'white',
+    'primary-text',
+    'secondary-text',
+    'disabled',
+]);
+
+// A theme color name becomes its CSS variable; anything else is passed through as a CSS color.
+// Equivalent to HA's computeCssColor, reimplemented because it is not exported to custom cards.
+export const computeCssColor = (color: string): string => (THEME_COLORS.has(color) ? `var(--${color}-color)` : color);
+
+export type ResolvedColor = { stateColor: boolean } | { cssColor: string };
+
+/**
+ * Resolve a config's effective icon color into a form that can be handed to state-badge.
+ *
+ * `color` wins, then the deprecated `state_color`. With neither set the default is "state" (HA
+ * 2026.8 colors entity rows by default) - EXCEPT when `icon_color` is configured, because that
+ * option paints the icon through CSS variables and an inline state color would beat it, silently
+ * dropping the user's color whenever the entity is active.
+ */
+export const resolveColor = (config: { color?: string; state_color?: boolean; icon_color?: string }): ResolvedColor => {
+    const color =
+        config.color ?? (config.state_color === undefined ? undefined : config.state_color ? 'state' : 'none');
+    if (color === undefined) {
+        return config.icon_color ? { stateColor: false } : { stateColor: true };
+    }
+    if (color === 'state') return { stateColor: true };
+    if (color === 'none') return { stateColor: false };
+    return { cssColor: computeCssColor(color) };
+};
+
+/**
+ * Properties to spread onto a state-badge for a resolved color.
+ *
+ * "state"/"none" are expressed as the legacy boolean `stateColor`, which HA 2026.8 maps back onto
+ * the new API internally - passing the literal string "state" as `color` would be rendered as raw
+ * CSS by pre-2026.8 state-badges and silently produce no color at all.
+ *
+ * A custom color is passed already computed, so it lands as a valid CSS color on both: older
+ * versions apply it unconditionally, 2026.8+ applies it while the entity is active.
+ */
+export const badgeColorProps = (resolved: ResolvedColor): { stateColor?: boolean; color?: string } =>
+    'cssColor' in resolved ? { color: resolved.cssColor } : { stateColor: resolved.stateColor };
+
+/**
+ * The same mapping in config form, for the config object handed to hui-generic-entity-row (which
+ * owns the main row's icon and forwards these to its own state-badge).
+ *
+ * A custom color only reaches the main icon on HA 2026.8+, since older hui-generic-entity-row
+ * versions do not forward `color` at all - `icon_color` remains the way to paint it there.
+ */
+export const rowColorConfig = (resolved: ResolvedColor): { state_color?: boolean; color?: string } =>
+    'cssColor' in resolved ? { color: resolved.cssColor } : { state_color: resolved.stateColor };

--- a/src/editor_schemas.ts
+++ b/src/editor_schemas.ts
@@ -60,7 +60,7 @@ export const MAIN_TAB_SCHEMA = [
         type: 'grid',
         schema: [
             { name: 'show_state', default: true, selector: { boolean: {} } },
-            { name: 'state_color', selector: { boolean: {} } },
+            { name: 'color', selector: { ui_color: { include_state: true, include_none: true } } },
         ],
     },
     {
@@ -117,7 +117,7 @@ export const ADDITIONAL_TAB_SCHEMA = [
     {
         type: 'grid',
         schema: [
-            { name: 'state_color', selector: { boolean: {} } },
+            { name: 'color', selector: { ui_color: { include_state: true, include_none: true } } },
             { name: 'toggle', selector: { boolean: {} } },
         ],
     },
@@ -138,6 +138,9 @@ export const LABELS: Record<string, string> = {
     show_state: 'Show main entity state',
     show_state_first: 'State before entities',
     state_header: 'State header label',
+    // state_color is still accepted in YAML as a deprecated alias, but the editor offers only the
+    // color selector - the same swap HA made in its own row editors (see #416).
+    color: 'Icon color',
     state_color: 'State color',
     column: 'Column layout',
     wrap: 'Wrap instead of overflowing',

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit';
 
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
+import { badgeColorProps, resolveColor, rowColorConfig } from './color';
 import { checkEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
 import { fireEvent, getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
 import { hasTemplate, resolveTemplateFields, templateDisplay, TemplateSubscriptions } from './templates';
@@ -143,7 +144,11 @@ class MultipleEntityRow extends LitElement {
         // A state_icon match overrides the main row's icon by injecting it into the config
         // handed to hui-generic-entity-row, which owns the main icon rendering (see #197).
         const mainStateIcon = stateIcon(this.stateObj, config);
-        const rowConfig = mainStateIcon ? { ...config, icon: mainStateIcon } : config;
+        const rowConfig = {
+            ...config,
+            ...(mainStateIcon ? { icon: mainStateIcon } : {}),
+            ...rowColorConfig(resolveColor(config)),
+        };
 
         // catchInteraction must stay false: despite the name it does NOT control whether
         // hui-generic-entity-row handles interaction (its actionHandler is bound to the .row
@@ -374,13 +379,17 @@ class MultipleEntityRow extends LitElement {
         // Resolution order: state_icon[state] (see #197) → explicit icon → entity's own icon.
         const overrideIcon =
             stateIcon(stateObj, config) ?? (config.icon === true ? stateObj.attributes.icon || null : config.icon);
+        // Exactly one of these is set (see badgeColorProps); the other stays undefined so
+        // state-badge falls through to the one that is.
+        const { stateColor, color } = badgeColorProps(resolveColor(config));
         return html`<state-badge
             class="icon-small"
             style="${iconColorCss(config.icon_color)}"
             .hass=${this._hass}
             .stateObj="${stateObj}"
             .overrideIcon="${overrideIcon}"
-            .stateColor="${config.state_color}"
+            .stateColor="${stateColor}"
+            .color="${color}"
         ></state-badge>`;
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -578,6 +578,54 @@ describe('multiple-entity-row', () => {
         });
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/416 - the resolution rules
+    // themselves are covered in color.test.ts; these pin how the result reaches HA's elements.
+    describe('icon color', () => {
+        const states = () => ({
+            'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+            'sensor.a': { entity_id: 'sensor.a', state: 'on', attributes: { icon: 'mdi:foo' } },
+        });
+        const rowConfig = async (config) => {
+            el.setConfig({ entity: 'sensor.main', ...config });
+            el.hass = buildHass(states());
+            await flushRender(el);
+            return el.shadowRoot.querySelector('hui-generic-entity-row').config;
+        };
+
+        it('colors the main row by state by default', async () => {
+            expect(await rowConfig({})).toMatchObject({ state_color: true });
+        });
+
+        it('passes color: none through as state_color false', async () => {
+            expect(await rowConfig({ color: 'none' })).toMatchObject({ state_color: false });
+        });
+
+        // A theme name must arrive as a CSS variable, and must NOT travel as state_color - the
+        // literal string "state" would be invalid CSS on pre-2026.8 state-badges.
+        it('passes a theme color as a computed CSS color', async () => {
+            const config = await rowConfig({ color: 'red' });
+            expect(config.color).toBe('var(--red-color)');
+            expect(config.state_color).toBeUndefined();
+        });
+
+        it('keeps icon_color working by not defaulting to state coloring', async () => {
+            expect(await rowConfig({ icon_color: 'red' })).toMatchObject({ state_color: false });
+        });
+
+        it('accepts the deprecated state_color', async () => {
+            expect(await rowConfig({ state_color: false })).toMatchObject({ state_color: false });
+        });
+
+        it('applies the resolved color to a sub-entity icon badge', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', icon: true, color: 'blue' }] });
+            el.hass = buildHass(states());
+            await flushRender(el);
+            const badge = el.shadowRoot.querySelector('.entity:not(.state) state-badge');
+            expect(badge.color).toBe('var(--blue-color)');
+            expect(badge.stateColor).toBeUndefined();
+        });
+    });
+
     describe('row layout', () => {
         beforeEach(() => {
             el.setConfig({ entity: 'sensor.main', entities: ['sensor.a'] });

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -68,6 +68,7 @@ export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
         add(entry.name, owner);
         add(entry.icon, owner);
         add(entry.icon_color, owner);
+        add(entry.color, owner);
         add(entry.template, owner);
         add(hideIfTemplate(entry), owner);
     };
@@ -112,6 +113,12 @@ export const resolveTemplateFields = <T extends LooseObject>(
     if (hasTemplate(config.icon_color)) {
         const result = get(config.icon_color);
         patch('icon_color', typeof result === 'string' ? result : '');
+    }
+    if (hasTemplate(config.color)) {
+        // A pending/failed color template must not resolve to the "state"/"none" default, so fall
+        // back to 'none' rather than dropping the key and re-triggering default state coloring.
+        const result = get(config.color);
+        patch('color', typeof result === 'string' && result !== '' ? result : 'none');
     }
     if (hasTemplate(config.template)) {
         patch('template', displayResult(get(config.template)));

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,9 @@ interface EntityOptions {
     icon?: string | boolean;
     icon_color?: string;
     state_icon?: Record<string, string>;
+    // "state" | "none" | a theme color name | any CSS color (HA 2026.8's color API; see color.ts).
+    color?: string;
+    /** @deprecated superseded by `color`; true/false map to "state"/"none". */
     state_color?: boolean;
     toggle?: boolean;
     hide_unavailable?: boolean;


### PR DESCRIPTION
HA 2026.8 replaced the boolean `state_color` with `color` (`state`, `none`, a theme color or a CSS color) and colors entity rows by default. This adds the same option on the row and on additional entities, defaulting to `state` so our rows stop looking different from built-in ones — a breaking change, restored with `color: none`.

Resolution maps onto the state-badge properties that behave correctly on every supported HA version rather than sniffing `hass.config.version`. Verified against both bundles in the testbed:

| | 2026.7 | 2026.8 |
|---|---|---|
| `state`/`none` | `stateColor ?? domain==='light'` | `stateColor!==undefined ? (stateColor?"state":"none")` |
| custom color | applied unconditionally | applied while active |

So state/none travel as the legacy `stateColor` boolean and custom colors travel already computed. Passing the literal `"state"` as `color` would be set as raw CSS by pre-2026.8 badges and silently render nothing.

A configured `icon_color` switches that entity's default to `none`: it paints through CSS variables, which an inline state color would beat, so the default would otherwise drop the user's color whenever the entity was active. An explicit `color` still wins over both.

`state_color` stays accepted as a deprecated alias and is replaced by HA's `ui_color` selector in the visual editor. Also includes a `HA_VERSION` override for the docker testbed, used to verify the above.

Refs #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)