### PR TITLE
Treat a whitespace-only name as no name (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 **Added:**
 - `color` option on the row and on additional entities, following HA's icon color API: `state`, `none`, a theme color name (`red`, `deep-purple`, ...) or any CSS color. Templatable like `icon_color`. Works back to HA 2024.4; theme colors and `state` need 2026.8+ for the main row icon (#416)
 
+**Fixed:**
+- `name: ' '` now behaves exactly like `name: false`. 4.8.0 gave it a reserved header line, which kept blank-named entities level with each other but pushed an all-blank row's values below the row name (#421)
+
 **Deprecated:**
 - `state_color` - still accepted and mapped to `color` (`true` → `state`, `false` → `none`), and no longer offered in the visual editor
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-entity-row",
-  "version": "4.9.0-beta.1",
+  "version": "4.9.0-beta.2",
   "description": "Show multiple entity states, attributes and icons on entity rows in Home Assistant's Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,12 @@ const stopBubble = (event) => event.stopPropagation();
 
 const NBSP = '\u00a0';
 
-// `name: ' '` is the long-standing idiom for "blank header, but keep the line". HTML collapses
-// that space, so the span ends up zero-height and the entity renders one line shorter than its
-// headered siblings - which since #281 includes the main state, whose placeholder is an nbsp and
-// does not collapse. Render any blank header as that same nbsp so both sides reserve a line and
-// stay level (see #418).
-const headerText = (text) => (typeof text === 'string' && text.trim() === '' ? NBSP : text);
+// `name: ' '` is the common idiom for "no header here" and must behave exactly like name:false,
+// so blank names collapse to null and go through the same headerPlaceholder path. #418 got this
+// wrong by rendering them as an nbsp: that kept blank-named entities level with each other, but
+// made an all-blank row reserve a header line nothing needed, dropping its values below the row
+// name (see #421). Whether a line is reserved is headerPlaceholder's decision alone.
+const blankName = (text) => (typeof text === 'string' && text.trim() === '' ? null : text);
 
 console.info(
     `%c MULTIPLE-ENTITY-ROW %c ${process.env.PACKAGE_VERSION} (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
@@ -246,7 +246,10 @@ class MultipleEntityRow extends LitElement {
                 // #302) - except when the entity is missing entirely, where only an explicit
                 // name can label it.
                 return html`<div class="entity" style="${entityStyles(config)}">
-                    <span>${headerText(stateObj ? entityName(stateObj, config) : config.name)}</span>
+                    <span
+                        >${blankName(stateObj ? entityName(stateObj, config) : config.name) ??
+                        this.headerPlaceholder()}</span
+                    >
                     <div>${config.default}</div>
                 </div>`;
             }
@@ -266,7 +269,7 @@ class MultipleEntityRow extends LitElement {
             @touchcancel="${stopBubble}"
             @contextmenu="${stopBubble}"
         >
-            <span>${headerText(entityName(stateObj, config)) ?? this.headerPlaceholder()}</span>
+            <span>${blankName(entityName(stateObj, config)) ?? this.headerPlaceholder()}</span>
             <div>
                 ${config.icon || isObject(config.state_icon)
                     ? this.renderIcon(stateObj, config)
@@ -278,7 +281,7 @@ class MultipleEntityRow extends LitElement {
     // Main-state counterpart of headerPlaceholder(): render the state_header, or reserve the
     // header line when sub-entities render headers so the main value stays level with theirs.
     renderMainHeader() {
-        const header = headerText(this.config.state_header) ?? this.headerPlaceholder();
+        const header = blankName(this.config.state_header) ?? this.headerPlaceholder();
         return header ? html`<span>${header}</span>` : null;
     }
 
@@ -287,9 +290,12 @@ class MultipleEntityRow extends LitElement {
     // #281). Reserve the header line with an nbsp - but only when some sibling actually renders
     // a header, so all-headerless rows keep their compact centered layout.
     headerPlaceholder() {
+        // name:false and name:' ' both mean "no header"; an unset name falls back to the entity's
+        // friendly name, which is one.
+        const rendersHeader = (config) =>
+            config.name !== false && blankName(config.name) !== null && !!(config.name || config.entity);
         const anyHeader =
-            this.config.state_header !== undefined ||
-            this.entities.some((entity) => entity.name !== false && (entity.name || entity.entity));
+            blankName(this.config.state_header) != null || this.entities.some((entity) => rendersHeader(entity));
         return anyHeader ? NBSP : null;
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -248,22 +248,26 @@ describe('multiple-entity-row', () => {
             expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
         });
 
-        // See https://github.com/benct/lovelace-multiple-entity-row/issues/418 - `name: ' '` is
-        // the idiom for a blank-but-present header. A literal space collapses to zero height, so
-        // that entity ended up a line shorter than the main state, whose #281 placeholder is a
-        // non-collapsing nbsp - the toggle/value misalignment reported against 4.7.1-beta.3.
-        it('reserves the header line for a whitespace-only name', async () => {
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/418 and #421 -
+        // `name: ' '` means "no header here" and must behave exactly like name:false. #418 first
+        // rendered it as an nbsp, which kept blank-named entities level with each other but made
+        // an all-blank row reserve a line nothing needed, pushing its values below the row name.
+        it('treats a whitespace-only name like name:false', async () => {
             el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', name: ' ' }] });
             el.hass = twoEntityHass();
             await flushRender(el);
             const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
-            // both the sub-entity's blank header and the main state's placeholder reserve a line
-            expect(spans.filter((span) => span.textContent === '\u00a0')).toHaveLength(2);
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
             expect(spans.some((span) => span.textContent === ' ')).toBe(false);
         });
 
-        it('reserves the header line for a whitespace-only state_header', async () => {
-            el.setConfig({ entity: 'sensor.main', state_header: ' ', entities: [{ entity: 'sensor.a' }] });
+        // ...but a blank name still needs the placeholder when a sibling does render a header,
+        // which is the alignment #281 was about.
+        it('reserves the header line for a blank name beside a headered sibling', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.a' }, { entity: 'sensor.b', name: ' ' }],
+            });
             el.hass = twoEntityHass();
             await flushRender(el);
             const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
@@ -271,8 +275,21 @@ describe('multiple-entity-row', () => {
             expect(spans.some((span) => span.textContent === ' ')).toBe(false);
         });
 
+        it('does not count a whitespace-only state_header as a header', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                state_header: ' ',
+                entities: [{ entity: 'sensor.a', name: false }],
+            });
+            el.hass = twoEntityHass();
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
+            expect(spans.some((span) => span.textContent === ' ')).toBe(false);
+        });
+
         // The default-value branch renders its own header span (see #302).
-        it('reserves the header line for a whitespace-only name on a hidden entity', async () => {
+        it('treats a whitespace-only name like name:false on a hidden entity', async () => {
             el.setConfig({
                 entity: 'sensor.main',
                 entities: [{ entity: 'sensor.a', name: ' ', hide_if: '1', default: 'n/a' }],
@@ -280,7 +297,7 @@ describe('multiple-entity-row', () => {
             el.hass = twoEntityHass();
             await flushRender(el);
             const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
-            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(true);
+            expect(spans.some((span) => span.textContent === '\u00a0')).toBe(false);
             expect(spans.some((span) => span.textContent === ' ')).toBe(false);
         });
     });


### PR DESCRIPTION
#418 rendered `name: ' '` as an nbsp so blank-named entities stayed level with each other, but that reserved a header line an all-blank row never needed, dropping its values and toggle below the row name.

`name: ' '` means "no header here" and now behaves exactly like `name: false`: blank names collapse to null and `headerPlaceholder` alone decides whether a line is reserved, ignoring blank names and a blank `state_header` when looking for a real sibling header. A blank name beside a genuinely headered sibling still gets the placeholder, which is the alignment #281 was about.

Refs #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)