### PR TITLE
Don't reserve a header line for non-text values (#425)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ multiple-entity-row.js.LICENSE.txt
 multiple-entity-row.js.gz
 coverage/
 .dev/ha-config/
+.dev/conversation*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**Fixed:**
+- Icons and toggles no longer reserve a header line when their name is hidden. The reserved line aligns text values with their headered siblings; a control has no baseline, so on rows mixing named values with icon-only entities it only added height (#425)
+
 ## 4.9.0
 
 **Breaking:**

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,18 @@ const NBSP = '\u00a0';
 // name (see #421). Whether a line is reserved is headerPlaceholder's decision alone.
 const blankName = (text) => (typeof text === 'string' && text.trim() === '' ? null : text);
 
+// The reserved header line exists so a blank-named entity's value shares a baseline with its
+// headered siblings' values (#281). A control has no baseline, so reserving one above it buys
+// nothing and just makes the row taller - which costs real information density on rows mixing
+// named values with icon-only entities (see #425). Of everything renderValue can produce, only
+// these two are non-text: an ha-entity-toggle and a state-badge. hui-timestamp-display and
+// ha-relative-time render ordinary text and must keep reserving.
+//
+// Sub-entity slots only. The main state slot renders text or a toggle and never an icon, because
+// a row-level `icon:` is the ROW's icon drawn by hui-generic-entity-row - feeding it through here
+// would make any row with an icon skip the placeholder for a perfectly ordinary text state.
+const rendersControl = (config) => config.toggle === true || !!config.icon || isObject(config.state_icon);
+
 console.info(
     `%c MULTIPLE-ENTITY-ROW %c ${process.env.PACKAGE_VERSION} (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
     'color: cyan; background: black; font-weight: bold;',
@@ -269,7 +281,10 @@ class MultipleEntityRow extends LitElement {
             @touchcancel="${stopBubble}"
             @contextmenu="${stopBubble}"
         >
-            <span>${blankName(entityName(stateObj, config)) ?? this.headerPlaceholder()}</span>
+            <span
+                >${blankName(entityName(stateObj, config)) ??
+                (rendersControl(config) ? null : this.headerPlaceholder())}</span
+            >
             <div>
                 ${config.icon || isObject(config.state_icon)
                     ? this.renderIcon(stateObj, config)
@@ -281,7 +296,10 @@ class MultipleEntityRow extends LitElement {
     // Main-state counterpart of headerPlaceholder(): render the state_header, or reserve the
     // header line when sub-entities render headers so the main value stays level with theirs.
     renderMainHeader() {
-        const header = blankName(this.config.state_header) ?? this.headerPlaceholder();
+        // Only `toggle` counts as a control here - see the rendersControl comment for why a
+        // row-level `icon:` must not.
+        const header =
+            blankName(this.config.state_header) ?? (this.config.toggle === true ? null : this.headerPlaceholder());
         return header ? html`<span>${header}</span>` : null;
     }
 
@@ -388,8 +406,15 @@ class MultipleEntityRow extends LitElement {
         // Exactly one of these is set (see badgeColorProps); the other stays undefined so
         // state-badge falls through to the one that is.
         const { stateColor, color } = badgeColorProps(resolveColor(config));
+        // state-badge shows an entity picture instead of an icon when the entity has one and no
+        // icon overrides it - and then it hides the icon and paints the picture as a background,
+        // so the host needs its fixed box or there is nothing to give it height. Deciding that
+        // here rather than leaning on state-badge's own has-image class, which it derives from
+        // this.style.backgroundImage and therefore always applies one render late.
+        const hasPicture =
+            !overrideIcon && !!(stateObj.attributes.entity_picture || stateObj.attributes.entity_picture_local);
         return html`<state-badge
-            class="icon-small"
+            class="icon-small${hasPicture ? ' has-picture' : ''}"
             style="${iconColorCss(config.icon_color)}"
             .hass=${this._hass}
             .stateObj="${stateObj}"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -288,6 +288,118 @@ describe('multiple-entity-row', () => {
             expect(spans.some((span) => span.textContent === ' ')).toBe(false);
         });
 
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/425 - the reserved line
+        // aligns text baselines, so a slot rendering a control (icon or toggle) should not get one:
+        // it only makes the row taller. Text renderers, including hui-timestamp-display and
+        // ha-relative-time, must keep reserving.
+        describe('non-text values', () => {
+            const withSibling = (entity) => ({
+                entity: 'sensor.main',
+                show_state: false,
+                entities: [{ entity: 'sensor.a' }, entity],
+            });
+            const nbspCount = () =>
+                [...el.shadowRoot.querySelectorAll('.entity span')].filter((s) => s.textContent === '\u00a0').length;
+
+            it('reserves no line for a blank-named icon entity', async () => {
+                el.setConfig(withSibling({ entity: 'sensor.b', name: false, icon: true }));
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(0);
+            });
+
+            it('reserves no line for a blank-named state_icon entity', async () => {
+                el.setConfig(withSibling({ entity: 'sensor.b', name: false, state_icon: { 2: 'mdi:check' } }));
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(0);
+            });
+
+            it('reserves no line for a blank-named toggle entity', async () => {
+                el.setConfig(withSibling({ entity: 'sensor.b', name: false, toggle: true }));
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(0);
+            });
+
+            it('still reserves a line for a blank-named text entity', async () => {
+                el.setConfig(withSibling({ entity: 'sensor.b', name: false }));
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(1);
+            });
+
+            // The icon box shrinks to the icon's natural height, but a picture-bearing entity
+            // needs the fixed box back: state-badge hides the icon and paints the picture as a
+            // background, so there is no in-flow content to give the host height.
+            it('marks a picture entity so its badge keeps a fixed box', async () => {
+                el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.pic', icon: true }] });
+                el.hass = buildHass({
+                    'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                    'sensor.pic': {
+                        entity_id: 'sensor.pic',
+                        state: 'on',
+                        attributes: { entity_picture: '/api/image/serve/abc' },
+                    },
+                });
+                await flushRender(el);
+                expect(el.shadowRoot.querySelector('state-badge').classList.contains('has-picture')).toBe(true);
+            });
+
+            it('does not mark a plain icon entity', async () => {
+                el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', icon: 'mdi:flash' }] });
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(el.shadowRoot.querySelector('state-badge').classList.contains('has-picture')).toBe(false);
+            });
+
+            // An explicit icon wins over the picture in state-badge, so the box should shrink.
+            it('does not mark a picture entity whose icon is overridden', async () => {
+                el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.pic', icon: 'mdi:flash' }] });
+                el.hass = buildHass({
+                    'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                    'sensor.pic': {
+                        entity_id: 'sensor.pic',
+                        state: 'on',
+                        attributes: { entity_picture: '/api/image/serve/abc' },
+                    },
+                });
+                await flushRender(el);
+                expect(el.shadowRoot.querySelector('state-badge').classList.contains('has-picture')).toBe(false);
+            });
+
+            it('still renders a real name on a control entity', async () => {
+                el.setConfig(withSibling({ entity: 'sensor.b', name: 'Fan', icon: true }));
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+                expect(spans.some((s) => s.textContent === 'Fan')).toBe(true);
+            });
+
+            it('reserves no line for a toggle main state', async () => {
+                el.setConfig({ entity: 'sensor.main', toggle: true, entities: [{ entity: 'sensor.a' }] });
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(0);
+            });
+
+            it('still reserves a line for a text main state', async () => {
+                el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a' }] });
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(1);
+            });
+
+            // A row-level `icon:` is the row's own icon, drawn by hui-generic-entity-row - it says
+            // nothing about what the main STATE slot renders, so it must not suppress the line.
+            it('still reserves a line for a text main state on a row with an icon', async () => {
+                el.setConfig({ entity: 'sensor.main', icon: 'mdi:flash', entities: [{ entity: 'sensor.a' }] });
+                el.hass = twoEntityHass();
+                await flushRender(el);
+                expect(nbspCount()).toBe(1);
+            });
+        });
+
         // The default-value branch renders its own header span (see #302).
         it('treats a whitespace-only name like name:false on a hidden entity', async () => {
             el.setConfig({

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,6 +1,16 @@
 export const style = (css) => css`
+    /* state-badge is a fixed 40px box, which leaves an odd gap under a headered icon - let it
+       shrink to the icon's natural size instead (see #425). */
     .icon-small {
         width: auto;
+        height: auto;
+    }
+    /* ...except when it is showing a picture: state-badge then hides the icon and paints the
+       image as a background, so the host has no in-flow content and would collapse to nothing.
+       The class is set in renderIcon rather than reusing state-badge's own has-image. */
+    .icon-small.has-picture {
+        width: 40px;
+        height: 40px;
     }
     .entity {
         text-align: center;


### PR DESCRIPTION
The reserved line exists so a blank-named entity's value shares a baseline with its headered siblings (#281). A control has no baseline, so reserving one above it only makes the row taller — costing real information density on rows that mix named values with icon-only entities.

Of everything `renderValue` produces, only two are non-text: an `ha-entity-toggle` and a `state-badge`. `hui-timestamp-display` and `ha-relative-time` render ordinary text and keep reserving.

The predicate is deliberately narrower for the main state slot, which renders text or a toggle but never an icon — a row-level `icon:` is the row's own icon, drawn by `hui-generic-entity-row`, and feeding it through would make any row with an icon skip the placeholder for an ordinary text state.

Also lets the icon box shrink to the icon's natural height instead of state-badge's fixed 40px, which left a gap under a headered icon. Picture-bearing entities keep the fixed box, flagged from the state object rather than state-badge's own `has-image` class — that one is derived from `this.style.backgroundImage` and so always lands a render late, which would have collapsed person and update entities on first paint.

Verified in the testbed across the mixed row from the report, the #281/#418/#421 configs, a row-level `icon:`, and both media-player and person picture entities.

Refs #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)