### PR TITLE
Add template variables and action templating (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+**Added:**
+- `vars` - named values usable in any template in the same scope, on the row and on additional entities, which inherit the row's and may shadow them. Values may themselves be templates, and a variable can build on one declared before it. Inlined into each template that uses them, so a field is still a single subscription (#422)
+- Templates inside `tap_action`/`hold_action`/`double_tap_action`, at any depth - service data, `target`, `navigation_path`, `confirmation.text`. Results keep their native type, and are resolved when the action fires so a service call carries current values (#422)
+
 **Fixed:**
 - Icons and toggles no longer reserve a header line when their name is hidden. The reserved line aligns text values with their headered siblings; a control has no baseline, so on rows mixing named values with icon-only entities it only added height (#425)
 

--- a/README.md
+++ b/README.md
@@ -42,31 +42,32 @@ This card produces an `entity-row` and must therefore be configured as an entity
 
 A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, digit-suffixed formats like `precision5`, [templates](#templating)) are YAML-only — a config containing templates opens directly in the code editor.
 
-| Name              | Type          | Default                             | Description                                      |
-| ----------------- | ------------- | ----------------------------------- | ------------------------------------------------ |
-| type              | string        | **Required**                        | `custom:multiple-entity-row`                     |
-| entity            | string        | **Required**                        | Entity ID (`domain.my_entity_id`)                |
-| attribute         | string        |                                     | Show an attribute instead of the state value     |
-| name              | string/bool   | `friendly_name`                     | Override entity friendly name                    |
-| unit              | string/bool   | `unit_of_measurement`               | Override entity unit of measurement              |
-| icon              | string        | `icon`                              | Override entity icon or image                    |
-| icon_color        | string        |                                     | CSS color for the entity icon                    |
-| state_icon        | object        |                                     | Map of state value → icon override               |
-| image             | string        |                                     | Show an image instead of icon                    |
-| toggle            | bool          | `false`                             | Display a toggle (if supported) instead of state |
-| show_state        | bool          | `true`                              | Set to `false` to hide the main entity           |
-| show_state_first  | bool          | `false`                             | Show the main state before other entities        |
-| state_header      | string        |                                     | Show header text above the main entity state     |
-| color             | string        | `state`                             | `state`, `none`, a theme color or a CSS color    |
-| state_color       | bool          | _deprecated_                        | Superseded by `color`                            |
-| column            | bool          | `false`                             | Show entities in a column instead of a row       |
-| wrap              | bool          | `false`                             | Wrap onto multiple lines instead of overflowing  |
-| default           | string        |                                     | Display this value when the state is hidden      |
-| hide_unavailable  | bool          | `false`                             | Hide the state value if unavailable              |
-| hide_if           | object/any    | _[Hiding](#hiding)_                 | Hide the state value if criteria match           |
-| styles            | object        |                                     | Add custom CSS styles to the state element       |
-| format            | string        | _[Formatting](#formatting)_         | Format main state/attribute value                |
-| template          | string        | _[Templating](#templating)_         | Replace the state value with a template result   |
+| Name             | Type        | Default                     | Description                                      |
+| ---------------- | ----------- | --------------------------- | ------------------------------------------------ |
+| type             | string      | **Required**                | `custom:multiple-entity-row`                     |
+| entity           | string      | **Required**                | Entity ID (`domain.my_entity_id`)                |
+| attribute        | string      |                             | Show an attribute instead of the state value     |
+| name             | string/bool | `friendly_name`             | Override entity friendly name                    |
+| unit             | string/bool | `unit_of_measurement`       | Override entity unit of measurement              |
+| icon             | string      | `icon`                      | Override entity icon or image                    |
+| icon_color       | string      |                             | CSS color for the entity icon                    |
+| state_icon       | object      |                             | Map of state value → icon override               |
+| image            | string      |                             | Show an image instead of icon                    |
+| toggle           | bool        | `false`                     | Display a toggle (if supported) instead of state |
+| show_state       | bool        | `true`                      | Set to `false` to hide the main entity           |
+| show_state_first | bool        | `false`                     | Show the main state before other entities        |
+| state_header     | string      |                             | Show header text above the main entity state     |
+| color            | string      | `state`                     | `state`, `none`, a theme color or a CSS color    |
+| state_color      | bool        | _deprecated_                | Superseded by `color`                            |
+| column           | bool        | `false`                     | Show entities in a column instead of a row       |
+| wrap             | bool        | `false`                     | Wrap onto multiple lines instead of overflowing  |
+| default          | string      |                             | Display this value when the state is hidden      |
+| hide_unavailable | bool        | `false`                     | Hide the state value if unavailable              |
+| hide_if          | object/any  | _[Hiding](#hiding)_         | Hide the state value if criteria match           |
+| styles           | object      |                             | Add custom CSS styles to the state element       |
+| format           | string      | _[Formatting](#formatting)_ | Format main state/attribute value                |
+| template         | string      | _[Templating](#templating)_ | Replace the state value with a template result   |
+| vars             | object      | _[Templating](#templating)_ | Named values reusable in this scope's templates  |
 |                   |
 | entities          | list          | _[Entity Objects](#entity-objects)_ | Additional entity IDs or entity object(s)        |
 | secondary_info    | string/object | _[Secondary Info](#secondary-info)_ | Custom `secondary_info` entity                   |
@@ -103,6 +104,7 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 | styles            | object      |                             | Add custom CSS styles to the entity element                        |
 | format            | string      | _[Formatting](#formatting)_ | Format entity value                                                |
 | template          | string      | _[Templating](#templating)_ | Replace the entity value with a template result                    |
+| vars              | object      | _[Templating](#templating)_ | Named values reusable in this scope's templates                    |
 | tap_action        | object      | _[Actions](#actions)_       | Custom entity tap action                                           |
 | hold_action       | object      | _[Actions](#actions)_       | Custom entity hold action                                          |
 | double_tap_action | object      | _[Actions](#actions)_       | Custom entity double-tap action                                    |
@@ -134,6 +136,7 @@ an object containing configuration options listed below, or any of the default s
 | hide_if          | object/any  | _[Hiding](#hiding)_         | Hide secondary info if its value matches given criteria  |
 | format           | string      | _[Formatting](#formatting)_ | Format secondary info value                              |
 | template         | string      | _[Templating](#templating)_ | Replace the secondary info value with a template result  |
+| vars             | object      | _[Templating](#templating)_ | Named values reusable in this scope's templates          |
 
 ### Actions
 
@@ -235,7 +238,7 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
 
 ### Templating
 
-Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `color`, `secondary_info` text, `hide_if`, and a `template` option that replaces the displayed value entirely. The `entity` variable holds the owning entity's id.
+Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `color`, `secondary_info` text, `hide_if`, a `template` option that replaces the displayed value entirely, and any value inside `tap_action`/`hold_action`/`double_tap_action`. The `entity` variable holds the owning entity's id, and `vars` lets you name values reused across a row.
 
 ```yaml
 - type: custom:multiple-entity-row

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -10,15 +10,67 @@ there is no separate `*_template` key.
 
 ## Supported options
 
-| Option           | Where                                    | Behavior                                              |
-| ---------------- | ---------------------------------------- | ----------------------------------------------------- |
-| `name`           | main row, additional entities, secondary | Result replaces the displayed name                    |
-| `secondary_info` | as a plain string                        | Result replaces the secondary text                    |
-| `icon`           | main row, additional entities            | Result is used as the icon (`mdi:...`)                |
-| `icon_color`     | main row, additional entities            | Result is used as the CSS color                       |
-| `color`          | main row, additional entities            | `state`, `none`, a theme color or a CSS color         |
-| `template`       | main row, additional entities, secondary | Result replaces the displayed state value entirely    |
-| `hide_if`        | as a plain string, or `hide_if.template` | Hides when the result renders true                    |
+| Option           | Where                                            | Behavior                                           |
+| ---------------- | ------------------------------------------------ | -------------------------------------------------- |
+| `name`           | main row, additional entities, secondary         | Result replaces the displayed name                 |
+| `secondary_info` | as a plain string                                | Result replaces the secondary text                 |
+| `icon`           | main row, additional entities                    | Result is used as the icon (`mdi:...`)             |
+| `icon_color`     | main row, additional entities                    | Result is used as the CSS color                    |
+| `color`          | main row, additional entities                    | `state`, `none`, a theme color or a CSS color      |
+| `template`       | main row, additional entities, secondary         | Result replaces the displayed state value entirely |
+| `hide_if`        | as a plain string, or `hide_if.template`         | Hides when the result renders true                 |
+| action configs   | `tap_action`, `hold_action`, `double_tap_action` | Any value inside them, at any depth                |
+
+## Variables (`vars`)
+
+Repeating the same lookup across a row gets noisy, so `vars` gives it a name. Variables are
+usable in every template in the same scope, and additional entities inherit the row's and may
+shadow them:
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: switch.nas_plex
+  vars:
+    host: "{{ state_attr(entity, 'host') }}"
+    display_name: "{{ state_attr(entity, 'display_name') }}"
+  name: "{{ display_name }} on {{ host }}"
+  entities:
+    - vars:
+        service_action: restart
+      icon: "mdi:{{ service_action }}"
+      tap_action:
+        action: perform-action
+        perform_action: button.press
+        confirmation:
+          text: "{{ service_action | capitalize }} {{ display_name }} on {{ host }}?"
+        target:
+          entity_id: "{{ 'button.' ~ [host, service_action] | join('_') | slugify }}"
+```
+
+A value may be a template or a plain literal, and a variable can build on one declared before it:
+
+```yaml
+vars:
+  raw: "{{ states(entity) | float(0) }}"
+  doubled: "{{ raw * 2 }}"
+  suffix: kWh
+```
+
+A variable whose value is a single `{{ … }}` expression keeps its native type, so numbers stay
+numbers and can be used in arithmetic. Anything with surrounding text or several expressions
+renders to a string.
+
+Variables cost nothing extra: they are inlined into each template that uses them, so a field is
+still a single subscription and Home Assistant still tracks the entities the variables touch.
+
+## Templates in actions
+
+Every value inside `tap_action`, `hold_action` and `double_tap_action` is templatable at any
+depth — service data, `target`, `navigation_path`, `confirmation.text`, and so on. Results keep
+their native type, so a template returning a number arrives as a number.
+
+Action templates are resolved when the action fires rather than when the row renders, so a
+service call always carries current values.
 
 ## The `entity` variable
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,14 @@ import { createGestureHandlers } from './lib/gesture_handler';
 import { badgeColorProps, resolveColor, rowColorConfig } from './color';
 import { checkEntity, entityName, entityStateDisplay, entityStyles, iconColorCss, stateIcon } from './entity';
 import { fireEvent, getEntityIds, hasConfigOrEntitiesChanged, hasGenericSecondaryInfo, hideIf, isObject } from './util';
-import { hasTemplate, resolveTemplateFields, templateDisplay, TemplateSubscriptions } from './templates';
+import {
+    hasTemplate,
+    resolveActionConfig,
+    resolveTemplateFields,
+    scopeVars,
+    templateDisplay,
+    TemplateSubscriptions,
+} from './templates';
 import { style } from './styles';
 import './editor';
 
@@ -145,7 +152,14 @@ class MultipleEntityRow extends LitElement {
     // templated. Resolution happens here at render time, so downstream display logic only ever
     // sees plain values.
     _resolved(config) {
-        return resolveTemplateFields(config, this._templateResults, config.entity ?? this.config.entity);
+        // scopeVars merges the row's `vars` with this scope's own; passing this.config as the
+        // entry for the row itself is a no-op merge, so every scope goes through one path.
+        return resolveTemplateFields(
+            config,
+            this._templateResults,
+            config.entity ?? this.config.entity,
+            scopeVars(this.config, config)
+        );
     }
 
     render() {
@@ -203,7 +217,7 @@ class MultipleEntityRow extends LitElement {
         }
         if (typeof secondaryInfo === 'string') {
             return html`${hasTemplate(secondaryInfo)
-                ? templateDisplay(this._templateResults, secondaryInfo, this.config.entity)
+                ? templateDisplay(this._templateResults, secondaryInfo, this.config.entity, scopeVars(this.config))
                 : secondaryInfo}`;
         }
         const config = this._resolved(secondaryInfo);
@@ -375,9 +389,18 @@ class MultipleEntityRow extends LitElement {
                       const exempt =
                           isObject(confirmation) &&
                           confirmation.exemptions?.some((exemption) => exemption.user === this._hass.user?.id);
-                      const text =
-                          (isObject(confirmation) && confirmation.text) ||
-                          `Are you sure you want to toggle ${entityName(stateObj, config) ?? stateObj.entity_id}?`;
+                      // The dialog reads confirmation.text straight from the config, so a
+                      // templated one has to be resolved here too or it shows raw Jinja.
+                      const configured = isObject(confirmation) && confirmation.text;
+                      const text = hasTemplate(configured)
+                          ? templateDisplay(
+                                this._templateResults,
+                                configured,
+                                config.entity ?? this.config.entity,
+                                scopeVars(this.config, config)
+                            )
+                          : configured ||
+                            `Are you sure you want to toggle ${entityName(stateObj, config) ?? stateObj.entity_id}?`;
                       if (exempt || confirm(text)) {
                           this._hass.callService('homeassistant', 'toggle', { entity_id: stateObj.entity_id });
                       }
@@ -456,14 +479,23 @@ class MultipleEntityRow extends LitElement {
     // supports newer action types (perform-action, assist) for free. Approach adopted from the
     // duczz/ha-multiple-entity-row fork.
     dispatchAction(entity, config, hold, dblClick) {
-        const actionConfig = dblClick
+        const raw = dblClick
             ? config.double_tap_action
             : hold
             ? config.hold_action
             : config.tap_action ?? { action: 'more-info' };
-        if (!actionConfig || actionConfig.action === 'none') {
+        if (!raw || raw.action === 'none') {
             return;
         }
+        // Resolved here rather than in _resolved: gesture handlers are cached until the next
+        // setConfig, so a config resolved at render time would be frozen at the first render
+        // (see resolveActionConfig). The owner must match what collectTemplates subscribed with.
+        const actionConfig = resolveActionConfig(
+            raw,
+            this._templateResults,
+            config.entity ?? this.config.entity,
+            scopeVars(this.config, config)
+        );
         const actionType = dblClick ? 'double_tap' : hold ? 'hold' : 'tap';
         fireEvent(this, 'hass-action', {
             config: {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -652,6 +652,64 @@ describe('multiple-entity-row', () => {
             expect(spans.some((span) => span.textContent === 'Wind')).toBe(true);
         });
 
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/422 - the whole point
+        // of inlining vars is that a field stays a single subscription; this is the end-to-end
+        // proof that the prefix survives the round trip through the element.
+        it('inlines vars into a field template and renders the result', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                vars: { host: "{{ state_attr(entity, 'host') }}" },
+                entities: [{ entity: 'sensor.a', vars: { act: 'restart' }, name: '{{ act }} on {{ host }}' }],
+            });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            expect(connection.subscribeMessage).toHaveBeenCalledTimes(1);
+            expect(connection.subs[0].message.template).toBe(
+                '{% set host = state_attr(entity, \'host\') %}{% set act = "restart" %}{{ act }} on {{ host }}'
+            );
+            connection.subs[0].callback({ result: 'restart on nas' });
+            await flushRender(el);
+            const spans = [...el.shadowRoot.querySelectorAll('.entity span')];
+            expect(spans.some((span) => span.textContent === 'restart on nas')).toBe(true);
+        });
+
+        // Gesture handlers are cached until the next setConfig, so an action config resolved at
+        // render time would be frozen at whatever the first render saw - including a pending
+        // result. Resolving at dispatch also means the service call carries current values.
+        it('resolves an action template when the action fires, not at first render', async () => {
+            const actions = [];
+            el.addEventListener('hass-action', (ev) => actions.push(ev.detail));
+            el.setConfig({
+                entity: 'sensor.main',
+                vars: { host: 'nas' },
+                entities: [
+                    {
+                        entity: 'sensor.a',
+                        tap_action: {
+                            action: 'call-service',
+                            service: 'button.press',
+                            service_data: { entity_id: "{{ 'button.' ~ host }}" },
+                        },
+                    },
+                ],
+            });
+            el.hass = hassWith(states());
+            await flushRender(el);
+
+            // fire once while the result is still pending
+            const gesture = el.getGestureHandlers('sub-0', 'sensor.a', el.config.entities[0]);
+            gesture.onDown();
+            gesture.onUp();
+            expect(actions[0].config.tap_action.service_data.entity_id).toBe('');
+
+            // the result lands; the SAME cached handler must now dispatch the resolved value
+            connection.subs[0].callback({ result: 'button.nas' });
+            await flushRender(el);
+            gesture.onDown();
+            gesture.onUp();
+            expect(actions[1].config.tap_action.service_data.entity_id).toBe('button.nas');
+        });
+
         it('hides and unhides an entity as its hide_if template verdict changes', async () => {
             el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', hide_if: '{{ hide }}' }] });
             el.hass = hassWith(states());

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -4,9 +4,12 @@ import {
     configHasTemplates,
     hasTemplate,
     isTruthyResult,
+    resolveActionConfig,
     resolveTemplateFields,
+    scopeVars,
     TemplateResults,
     TemplateSubscriptions,
+    varsPrefix,
 } from './templates';
 
 const NAME_TEMPLATE = "{{ states('sensor.a') }} name";
@@ -131,6 +134,151 @@ describe('collectTemplates', () => {
     });
 });
 
+// See https://github.com/benct/lovelace-multiple-entity-row/issues/422 - `vars` are inlined as
+// {% set %} statements ahead of each templated field in the same scope, so a field stays one
+// subscription and HA still tracks the entities the variables touch.
+describe('varsPrefix', () => {
+    it('is empty without vars', () => {
+        expect(varsPrefix(undefined)).toBe('');
+        expect(varsPrefix({})).toBe('');
+    });
+
+    // Unwrapped so the variable keeps its native type rather than becoming a string.
+    it('unwraps a lone expression', () => {
+        expect(varsPrefix({ host: "{{ state_attr(entity, 'host') }}" })).toBe(
+            "{% set host = state_attr(entity, 'host') %}"
+        );
+    });
+
+    // Surrounding text or a second expression can't be unwrapped, so capture the rendered output.
+    it('captures anything that is not a lone expression', () => {
+        expect(varsPrefix({ label: 'host {{ a }}' })).toBe('{% set label %}host {{ a }}{% endset %}');
+        expect(varsPrefix({ label: '{{ a }}{{ b }}' })).toBe('{% set label %}{{ a }}{{ b }}{% endset %}');
+        expect(varsPrefix({ label: '{% if x %}y{% endif %}' })).toBe(
+            '{% set label %}{% if x %}y{% endif %}{% endset %}'
+        );
+    });
+
+    it('emits literals as Jinja values', () => {
+        expect(varsPrefix({ action: 'restart' })).toBe('{% set action = "restart" %}');
+        expect(varsPrefix({ n: 5 })).toBe('{% set n = 5 %}');
+        expect(varsPrefix({ flag: true })).toBe('{% set flag = true %}');
+        expect(varsPrefix({ nothing: null })).toBe('{% set nothing = none %}');
+    });
+
+    it('preserves declaration order so a variable can build on an earlier one', () => {
+        expect(varsPrefix({ a: '{{ 1 }}', b: '{{ a + 1 }}' })).toBe('{% set a = 1 %}{% set b = a + 1 %}');
+    });
+});
+
+describe('scopeVars', () => {
+    it('merges row vars with the scope, the scope winning', () => {
+        expect(scopeVars({ vars: { host: 'h', action: 'stop' } }, { vars: { action: 'restart' } })).toEqual({
+            host: 'h',
+            action: 'restart',
+        });
+    });
+
+    it('is a no-op merge for the row itself', () => {
+        const config = { vars: { host: 'h' } };
+        expect(scopeVars(config, config)).toEqual({ host: 'h' });
+    });
+});
+
+describe('collectTemplates with vars', () => {
+    it('prefixes each templated field with the scope vars', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            vars: { host: '{{ 1 }}' },
+            name: '{{ host }}',
+        });
+        expect(requests).toEqual([{ template: '{% set host = 1 %}{{ host }}', entity: 'sensor.main' }]);
+    });
+
+    it('gives a sub-entity the merged row+entity vars', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            vars: { host: '{{ 1 }}' },
+            entities: [{ entity: 'sensor.a', vars: { act: 'stop' }, name: '{{ host }}{{ act }}' }],
+        });
+        expect(requests).toEqual([
+            {
+                template: '{% set host = 1 %}{% set act = "stop" %}{{ host }}{{ act }}',
+                entity: 'sensor.a',
+            },
+        ]);
+    });
+
+    // vars alone are not a subscription - they only exist as part of a field's template.
+    it('does not subscribe to vars on their own', () => {
+        expect(collectTemplates({ entity: 'sensor.main', vars: { host: '{{ 1 }}' }, name: 'plain' })).toEqual([]);
+    });
+});
+
+// See https://github.com/benct/lovelace-multiple-entity-row/issues/422 - action configs are
+// walked rather than enumerated, so a template works anywhere inside one.
+describe('action config templating', () => {
+    const config = {
+        entity: 'sensor.main',
+        vars: { host: 'nas' },
+        entities: [
+            {
+                entity: 'sensor.a',
+                tap_action: {
+                    action: 'call-service',
+                    service: 'button.press',
+                    confirmation: { text: 'Restart {{ host }}?' },
+                    service_data: { entity_id: "{{ 'button.' ~ host }}", brightness: '{{ 255 }}' },
+                },
+            },
+        ],
+    };
+
+    it('collects templates from anywhere inside an action config', () => {
+        expect(collectTemplates(config).map((r) => r.template)).toEqual([
+            '{% set host = "nas" %}Restart {{ host }}?',
+            '{% set host = "nas" %}{{ \'button.\' ~ host }}',
+            '{% set host = "nas" %}{{ 255 }}',
+        ]);
+    });
+
+    it('replaces templated values while leaving the rest of the config alone', () => {
+        const results: TemplateResults = new Map<string, unknown>([
+            ['sensor.a|{% set host = "nas" %}Restart {{ host }}?', 'Restart nas?'],
+            ['sensor.a|{% set host = "nas" %}{{ \'button.\' ~ host }}', 'button.nas'],
+            ['sensor.a|{% set host = "nas" %}{{ 255 }}', 255],
+        ]);
+        const resolved = resolveActionConfig(
+            config.entities[0].tap_action,
+            results,
+            'sensor.a',
+            scopeVars(config, config.entities[0])
+        );
+        expect(resolved).toEqual({
+            action: 'call-service',
+            service: 'button.press',
+            confirmation: { text: 'Restart nas?' },
+            service_data: { entity_id: 'button.nas', brightness: 255 },
+        });
+    });
+
+    // Service data often wants a real number or boolean, so results are used natively rather
+    // than stringified the way display fields are.
+    it('keeps native result types', () => {
+        const results: TemplateResults = new Map([['sensor.a|{{ n }}', 42]]);
+        expect(resolveActionConfig({ data: { v: '{{ n }}' } }, results, 'sensor.a')).toEqual({ data: { v: 42 } });
+    });
+
+    it('renders a pending result as empty rather than leaking Jinja into a service call', () => {
+        expect(resolveActionConfig({ data: { v: '{{ n }}' } }, new Map(), 'sensor.a')).toEqual({ data: { v: '' } });
+    });
+
+    it('returns a config with no templates untouched', () => {
+        const plain = { action: 'toggle' };
+        expect(resolveActionConfig(plain, new Map(), 'sensor.a')).toEqual(plain);
+    });
+});
+
 describe('resolveTemplateFields', () => {
     const empty: TemplateResults = new Map();
 
@@ -191,6 +339,26 @@ describe('resolveTemplateFields', () => {
         const { connection, results } = buildManager(config);
         connection.subs[0].callback({ result: { a: 1 } });
         expect(resolveTemplateFields(config, results(), 'sensor.a').template).toBe('{"a":1}');
+    });
+
+    // The prefix is part of the subscribed string and therefore part of the result key. This is
+    // the round trip that catches collect and resolve building it differently - the failure mode
+    // is silent, every lookup simply missing (see #422).
+    it('round-trips a result through the vars prefix', () => {
+        const config = { entity: 'sensor.a', vars: { host: "{{ 'kitchen' }}" }, name: '{{ host }}' };
+        const { connection, results } = buildManager(config);
+        expect(connection.subs[0].message.template).toBe("{% set host = 'kitchen' %}{{ host }}");
+        connection.subs[0].callback({ result: 'kitchen' });
+        expect(resolveTemplateFields(config, results(), 'sensor.a', scopeVars(config, config)).name).toBe('kitchen');
+    });
+
+    it('misses nothing when a sub-entity shadows a row var', () => {
+        const entry = { entity: 'sensor.b', vars: { act: 'restart' }, name: '{{ act }}' };
+        const config = { entity: 'sensor.a', vars: { act: 'stop' }, entities: [entry] };
+        const { connection, results } = buildManager(config);
+        expect(connection.subs[0].message.template).toBe('{% set act = "restart" %}{{ act }}');
+        connection.subs[0].callback({ result: 'restart' });
+        expect(resolveTemplateFields(entry, results(), 'sensor.b', scopeVars(config, entry)).name).toBe('restart');
     });
 });
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -59,28 +59,112 @@ const displayResult = (result: unknown): string =>
 // gets different `entity` variables, so the results are distinct.
 const resultKey = (template: string, entity?: string): string => `${entity ?? ''}|${template}`;
 
+// A single {{ ... }} expression with nothing around it and no other expression inside.
+const SINGLE_EXPRESSION = /^\{\{((?:(?!\}\}).)*)\}\}$/s;
+
+// One `vars` entry as a Jinja assignment. A lone expression is unwrapped so the variable keeps
+// its native type ({% set n = states(x)|float %} stays a number); anything with surrounding text
+// or several expressions goes through the capture form, which always yields a string.
+const setStatement = (name: string, value: unknown): string => {
+    if (typeof value === 'string' && hasTemplate(value)) {
+        const single = SINGLE_EXPRESSION.exec(value.trim());
+        return single ? `{% set ${name} = ${single[1].trim()} %}` : `{% set ${name} %}${value}{% endset %}`;
+    }
+    // Jinja's null literal is `none`; everything else JSON happens to share Jinja's syntax.
+    return `{% set ${name} = ${value === null || value === undefined ? 'none' : JSON.stringify(value)} %}`;
+};
+
+/**
+ * `vars` as a run of {% set %} statements to prepend to every templated field in the same scope
+ * (see #422). Inlining keeps one subscription per field - HA renders the variables as part of
+ * that template and tracks the entities they touch - instead of needing a second round of
+ * subscriptions whose results feed the first.
+ *
+ * Declaration order is preserved, so a variable can build on an earlier one.
+ *
+ * This prefix is part of the string handed to HA and therefore part of the result cache key, so
+ * collect and resolve MUST build it from this one helper or every lookup silently misses.
+ */
+export const varsPrefix = (vars: unknown): string =>
+    isObject(vars)
+        ? Object.entries(vars as LooseObject)
+              .map(([name, value]) => setStatement(name, value))
+              .join('')
+        : '';
+
+const ACTION_KEYS = ['tap_action', 'hold_action', 'double_tap_action'];
+
+// Action configs are walked rather than enumerated: templates are just as useful in
+// confirmation.text as in service data, a navigation_path or a target, and HA keeps adding
+// action types. Anything that is a string containing Jinja is a template, wherever it sits.
+const walkTemplates = (value: unknown, visit: (template: string) => void): void => {
+    if (hasTemplate(value)) visit(value);
+    else if (Array.isArray(value)) value.forEach((item) => walkTemplates(item, visit));
+    else if (isObject(value)) Object.values(value as LooseObject).forEach((item) => walkTemplates(item, visit));
+};
+
+/**
+ * A copy of one action config with its templated values replaced by current results (see #422).
+ *
+ * Resolved when the action fires rather than at render time: gesture handlers are cached until
+ * the next setConfig, so anything baked in at render would be frozen at whatever the first render
+ * saw - including still-pending results. Firing time also means the service call carries the
+ * values as they are at the moment of the tap.
+ */
+export const resolveActionConfig = <T>(action: T, results: TemplateResults, owner?: string, vars?: LooseObject): T => {
+    const prefix = varsPrefix(vars);
+    const resolve = (value: unknown): unknown => {
+        if (hasTemplate(value)) {
+            // Native result, not a display string - service data frequently wants numbers or
+            // booleans. A pending result becomes '' rather than leaking Jinja into a service call.
+            const result = results.get(resultKey(prefix + value, owner));
+            return result === undefined ? '' : result;
+        }
+        if (Array.isArray(value)) return value.map(resolve);
+        if (isObject(value)) {
+            return Object.fromEntries(Object.entries(value as LooseObject).map(([key, v]) => [key, resolve(v)]));
+        }
+        return value;
+    };
+    return resolve(action) as T;
+};
+
+/** Row-level `vars` merged with a scope's own, the scope winning. Sub-entities inherit the row's
+ * variables and may shadow them. Must match what index.js hands resolveTemplateFields. */
+export const scopeVars = (config: LooseObject, entry?: LooseObject): LooseObject => ({
+    ...(isObject(config.vars) ? (config.vars as LooseObject) : {}),
+    ...(entry && isObject(entry.vars) ? (entry.vars as LooseObject) : {}),
+});
+
 export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
     const requests: TemplateRequest[] = [];
-    const add = (template: unknown, entity?: string): void => {
-        if (hasTemplate(template)) requests.push({ template, entity });
+    // hasTemplate is checked against the raw field - the prefix itself contains {% %} and would
+    // otherwise make every field look templated.
+    const add = (template: unknown, entity?: string, prefix = ''): void => {
+        if (hasTemplate(template)) requests.push({ template: prefix + template, entity });
     };
-    const collectEntry = (entry: LooseObject, owner?: string): void => {
-        add(entry.name, owner);
-        add(entry.icon, owner);
-        add(entry.icon_color, owner);
-        add(entry.color, owner);
-        add(entry.template, owner);
-        add(hideIfTemplate(entry), owner);
+    const collectEntry = (entry: LooseObject, owner?: string, prefix = ''): void => {
+        add(entry.name, owner, prefix);
+        add(entry.icon, owner, prefix);
+        add(entry.icon_color, owner, prefix);
+        add(entry.color, owner, prefix);
+        add(entry.template, owner, prefix);
+        add(hideIfTemplate(entry), owner, prefix);
+        ACTION_KEYS.forEach((key) => walkTemplates(entry[key], (template) => add(template, owner, prefix)));
     };
     const main = config.entity as string | undefined;
-    collectEntry(config, main);
+    collectEntry(config, main, varsPrefix(scopeVars(config)));
     if (typeof config.secondary_info === 'string') {
-        add(config.secondary_info, main);
+        add(config.secondary_info, main, varsPrefix(scopeVars(config)));
     } else if (isObject(config.secondary_info)) {
-        collectEntry(config.secondary_info, config.secondary_info.entity ?? main);
+        const info = config.secondary_info as LooseObject;
+        collectEntry(info, (info.entity as string) ?? main, varsPrefix(scopeVars(config, info)));
     }
     (config.entities as unknown[] | undefined)?.forEach((entry) => {
-        if (isObject(entry)) collectEntry(entry as LooseObject, (entry as LooseObject).entity ?? main);
+        if (isObject(entry)) {
+            const item = entry as LooseObject;
+            collectEntry(item, (item.entity as string) ?? main, varsPrefix(scopeVars(config, item)));
+        }
     });
     return requests;
 };
@@ -90,14 +174,17 @@ export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
 export const resolveTemplateFields = <T extends LooseObject>(
     config: T,
     results: TemplateResults,
-    owner?: string
+    owner?: string,
+    vars?: LooseObject
 ): T => {
     let resolved = config;
     const patch = (key: string, value: unknown): void => {
         if (resolved === config) resolved = { ...config };
         (resolved as LooseObject)[key] = value;
     };
-    const get = (template: string): unknown => results.get(resultKey(template, owner));
+    // Same prefix collectTemplates subscribed with, or the key misses (see varsPrefix).
+    const prefix = varsPrefix(vars);
+    const get = (template: string): unknown => results.get(resultKey(prefix + template, owner));
 
     if (hasTemplate(config.name)) {
         // An empty name would fall back to the entity's friendly name in entityName - a pending
@@ -133,8 +220,12 @@ export const resolveTemplateFields = <T extends LooseObject>(
 };
 
 /** Current display string for a standalone template (e.g. a templated secondary_info string). */
-export const templateDisplay = (results: TemplateResults, template: string, entity?: string): string =>
-    displayResult(results.get(resultKey(template, entity)));
+export const templateDisplay = (
+    results: TemplateResults,
+    template: string,
+    entity?: string,
+    vars?: LooseObject
+): string => displayResult(results.get(resultKey(varsPrefix(vars) + template, entity)));
 
 type UnsubscribeFunc = () => Promise<void> | void;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,9 @@ interface EntityOptions {
     format?: string;
     // Jinja template replacing the displayed state (rendered server-side; see templates.ts).
     template?: string;
+    // Named values usable inside this scope's templates; sub-entities inherit the row's and may
+    // shadow them. Values may themselves be templates (see #422).
+    vars?: Record<string, unknown>;
     attribute?: string;
     unit?: string | false;
     name?: string | false;


### PR DESCRIPTION
Two related additions from #422.

**`vars`** names values reusable across a scope's templates. Row-level variables are inherited by additional entities, which may shadow them, and a variable can build on one declared before it.

They're inlined as `{% set %}` statements ahead of each templated field in the same scope, rather than rendered separately and fed in as subscription variables. That keeps a field to a single subscription, lets HA keep tracking the entities the variables touch, and makes ordering fall out for free. A lone `{{ … }}` value is unwrapped so it keeps its native type; surrounding text forces the capture form, which yields a string.

The prefix is part of the subscribed string and therefore part of the result cache key, so collect and resolve build it from one helper — a round-trip test covers divergence, which would otherwise fail silently as every lookup simply missing.

**Action configs** are now walked for templates at any depth: service data, `target`, `navigation_path`, `confirmation.text`. Results keep their native type, since service data frequently wants a number or boolean.

These resolve when the action fires rather than at render time. Gesture handlers are cached until the next `setConfig`, so a config resolved at render would freeze at whatever the first render saw, including still-pending results; dispatch-time resolution also means the call carries current values. The toggle confirmation reads `confirmation.text` straight from the config, so that path resolves it separately or it would show raw Jinja.

Docs in [docs/templating.md](https://github.com/benct/lovelace-multiple-entity-row/blob/master/docs/templating.md). Verified in the testbed with the reporter's shape: shared row variables driving a sub-entity's icon, label, service name, confirmation text and target.

Refs #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)