### PR TITLE
Allow entity-less entries and mark missing entities (#340, #364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 **Added:**
 - `vars` - named values usable in any template in the same scope, on the row and on additional entities, which inherit the row's and may shadow them. Values may themselves be templates, and a variable can build on one declared before it. Inlined into each template that uses them, so a field is still a single subscription (#422)
 - Templates inside `tap_action`/`hold_action`/`double_tap_action`, at any depth - service data, `target`, `navigation_path`, `confirmation.text`. Results keep their native type, and are resolved when the action fires so a service call carries current values (#422)
+- An additional entity no longer needs `entity`, `attribute` or `icon` - an entry with none of them (even `- {}`) shows the main entity's state, which is the only way to repeat it when the id isn't known in advance, as under `custom:auto-entities` (#340)
+
+**Changed:**
+- An entity id that doesn't resolve is now marked with a warning icon instead of silently disappearing from the row. `hide_unavailable: true` hides it as before, and `default:` still takes precedence (#364)
 
 **Fixed:**
 - Icons and toggles no longer reserve a header line when their name is hidden. The reserved line aligns text values with their headered siblings; a control has no baseline, so on rows mixing named values with icon-only entities it only added height (#425)

--- a/README.md
+++ b/README.md
@@ -81,10 +81,14 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 Similarly as the default HA `entities` card, each entity can be specified by an entity ID string,
 or by an object which allows more customization and configuration.
 
-If you define entities as objects, either `entity`, `attribute` or `icon` needs to be specified. `entity` is only required if you want
-to display data from another entity than the main entity specified above. `attribute` is necessary if you want to display an entity
+If you define entities as objects, every option is optional. `entity` is only required if you want to display data from another
+entity than the main entity specified above — leave it out (even `- {}` on its own) to show the main entity's state again, which is
+useful when the id isn't known in advance, as under `custom:auto-entities`. `attribute` is necessary if you want to display an entity
 attribute value instead of the state value. `icon` lets you display an icon instead of a state or attribute value
 (works well together with a custom `tap_action`).
+
+An entity id that doesn't resolve is marked with a warning icon rather than silently dropped, so a renamed or removed entity is
+visible. Use `hide_unavailable: true` to hide it instead, or `default:` to show a placeholder value.
 
 | Name              | Type        | Default                     | Description                                                        |
 | ----------------- | ----------- | --------------------------- | ------------------------------------------------------------------ |

--- a/src/entity.js
+++ b/src/entity.js
@@ -2,10 +2,13 @@ import { secondsToDuration } from './lib/seconds_to_duration';
 import { formatNumber } from './lib/format_number';
 import { isObject, isUnavailable } from './util';
 
+// An entry used to need one of entity/attribute/icon, on the reasoning that it would otherwise
+// render nothing. That stopped being true: an entry with no `entity` already falls back to the
+// row's main entity, so `- {}` is a meaningful way to repeat the main state - which is the only
+// way to get it under auto-entities, where the id isn't known when the config is written
+// (see #340). Only the string/type checks are real validation now.
 export const checkEntity = (config) => {
-    if (isObject(config) && !(config.entity || config.attribute || config.icon)) {
-        throw new Error(`Entity object requires at least one 'entity', 'attribute' or 'icon'.`);
-    } else if (typeof config === 'string' && config === '') {
+    if (typeof config === 'string' && config === '') {
         throw new Error('Entity ID string must not be blank.');
     } else if (typeof config !== 'string' && !isObject(config)) {
         throw new Error('Entity config must be a valid entity ID string or entity object.');

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -34,8 +34,12 @@ describe('checkEntity', () => {
         expect(() => checkEntity('')).toThrow(/must not be blank/);
     });
 
-    it('throws for an object missing entity, attribute and icon', () => {
-        expect(() => checkEntity({ name: 'Foo' })).toThrow(/requires at least one/);
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/340 - an entry without
+    // `entity` falls back to the row's main entity, so an empty or name-only object is a valid
+    // way to repeat the main state rather than a config error.
+    it('accepts an object with no entity, attribute or icon', () => {
+        expect(() => checkEntity({})).not.toThrow();
+        expect(() => checkEntity({ name: 'Foo' })).not.toThrow();
     });
 
     it('throws for any other config shape', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -279,6 +279,24 @@ class MultipleEntityRow extends LitElement {
                     <div>${config.default}</div>
                 </div>`;
             }
+            // A missing entity is nearly always a renamed or removed id, and dropping the slot
+            // silently leaves no clue which one (see #364). `hide_unavailable` is documented as
+            // the way to hide an entity that "is unavailable or does not exist", so honour that
+            // and mark the gap otherwise. Not a header slot: the marker is an icon (see #425).
+            if (!stateObj && !config.hide_unavailable) {
+                return html`<div
+                    class="entity"
+                    style="${entityStyles(config)}"
+                    title="${this._hass.localize(
+                        'ui.panel.lovelace.warning.entity_not_found',
+                        'entity',
+                        config.entity ?? ''
+                    )}"
+                >
+                    <span>${blankName(config.name)}</span>
+                    <div><ha-icon class="missing" icon="mdi:alert-circle-outline"></ha-icon></div>
+                </div>`;
+            }
             return null;
         }
         const gesture = this.getGestureHandlers(`sub-${index}`, stateObj.entity_id, config);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -34,12 +34,23 @@ describe('multiple-entity-row', () => {
         expect(() => el.setConfig({})).toThrow('Please define a main entity.');
     });
 
-    // See https://github.com/benct/lovelace-multiple-entity-row/issues/364 -
-    // an invalid entities/secondary_info config should fail fast at setConfig time.
+    // A malformed entry still fails fast at setConfig time. Distinct from #364, which is about an
+    // entity id that is well-formed but resolves to nothing at runtime.
     it('throws when an entities item is invalid', () => {
-        expect(() => el.setConfig({ entity: 'sensor.main', entities: [{ name: 'no entity/attribute/icon' }] })).toThrow(
-            /requires at least one/
+        expect(() => el.setConfig({ entity: 'sensor.main', entities: [42] })).toThrow(
+            /valid entity ID string or entity object/
         );
+        expect(() => el.setConfig({ entity: 'sensor.main', entities: [''] })).toThrow(/must not be blank/);
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/340 - repeating the main
+    // entity's state without naming it again, which is the only way under auto-entities.
+    it('renders the main entity state for an entry with no entity of its own', async () => {
+        el.setConfig({ entity: 'sensor.main', entities: [{}, { name: 'Copy' }] });
+        el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: '21', attributes: {} } });
+        await flushRender(el);
+        const values = [...el.shadowRoot.querySelectorAll('.entity:not(.state) div')].map((d) => d.textContent.trim());
+        expect(values).toEqual(['21', '21']);
     });
 
     it('tracks entity ids from the main entity, entities list and secondary_info', () => {
@@ -160,6 +171,52 @@ describe('multiple-entity-row', () => {
         await flushRender(el);
         expect(el.shadowRoot.innerHTML).toContain('Alpha');
         expect(el.shadowRoot.innerHTML).toContain('n/a');
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/364 - a removed or renamed
+    // entity id used to vanish from the row with no clue which slot it was.
+    describe('missing entity', () => {
+        const hassWithoutB = () =>
+            buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+
+        it('marks a missing entity instead of dropping the slot', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.gone', name: 'Gone' }] });
+            el.hass = hassWithoutB();
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.entity .missing')).not.toBeNull();
+            expect(el.shadowRoot.innerHTML).toContain('Gone');
+        });
+
+        // hide_unavailable is documented as hiding an entity that is unavailable OR absent.
+        it('still hides a missing entity with hide_unavailable', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                entities: [{ entity: 'sensor.gone', hide_unavailable: true }],
+            });
+            el.hass = hassWithoutB();
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.entity .missing')).toBeNull();
+            expect(el.shadowRoot.querySelectorAll('.entity:not(.state)')).toHaveLength(0);
+        });
+
+        it('prefers a configured default over the marker', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.gone', default: 'n/a' }] });
+            el.hass = hassWithoutB();
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.entity .missing')).toBeNull();
+            expect(el.shadowRoot.innerHTML).toContain('n/a');
+        });
+
+        // An entity that exists but is merely unavailable is a normal state, not a missing id.
+        it('does not mark an entity that exists but is unavailable', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a' }] });
+            el.hass = buildHass({
+                'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                'sensor.a': { entity_id: 'sensor.a', state: 'unavailable', attributes: {} },
+            });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.entity .missing')).toBeNull();
+        });
     });
 
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/265 - a confirmation on

--- a/src/styles.js
+++ b/src/styles.js
@@ -16,6 +16,10 @@ export const style = (css) => css`
         text-align: center;
         cursor: pointer;
     }
+    /* Marker for an entity id that resolves to nothing (see #364). */
+    .entity .missing {
+        color: var(--error-color, #db4437);
+    }
     .entity span {
         font-size: 10px;
         color: var(--multiple-entity-row-header-color, var(--secondary-text-color));


### PR DESCRIPTION
**#340** — an additional entity no longer needs one of `entity`/`attribute`/`icon`. An entry without `entity` already falls back to the row's main entity, so `- {}` is a meaningful way to repeat the main state, and the only way to get it under `custom:auto-entities` where the id isn't known when the config is written. The rule also protected against typos inconsistently: a mistyped key on an entry that had any of the three was always ignored silently.

**#364** — a missing entity id is now marked with a warning icon rather than dropped. Silently removing the slot left no clue which entity had been renamed or removed, and `hide_unavailable` is documented as hiding an entity that "is unavailable or does not exist" — so hiding unconditionally made that option meaningless. It now does the opting out, and `default:` still takes precedence.

Note this changes existing behaviour: a row with a dead entity id will start showing a warning icon where there was previously a silent gap.

Refs #340, #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)