### PR TITLE
Show remaining time for timer entities (#65, #299, #350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - `vars` - named values usable in any template in the same scope, on the row and on additional entities, which inherit the row's and may shadow them. Values may themselves be templates, and a variable can build on one declared before it. Inlined into each template that uses them, so a field is still a single subscription (#422)
 - Templates inside `tap_action`/`hold_action`/`double_tap_action`, at any depth - service data, `target`, `navigation_path`, `confirmation.text`. Results keep their native type, and are resolved when the action fires so a service call carries current values (#422)
 - An additional entity no longer needs `entity`, `attribute` or `icon` - an entry with none of them (even `- {}`) shows the main entity's state, which is the only way to repeat it when the id isn't known in advance, as under `custom:auto-entities` (#340)
+- Timer entities show their remaining time instead of the raw `active`/`idle`/`paused` state - the localized state while idle, a counting `mm:ss` while running, and `mm:ss (Paused)` when paused, matching HA's own timer row. An explicit `attribute:` or `template:` still wins (#65, #299, #350)
 
 **Changed:**
 - An entity id that doesn't resolve is now marked with a warning icon instead of silently disappearing from the row. `hide_unavailable: true` hides it as before, and `default:` still takes precedence (#364)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ attribute value instead of the state value. `icon` lets you display an icon inst
 An entity id that doesn't resolve is marked with a warning icon rather than silently dropped, so a renamed or removed entity is
 visible. Use `hide_unavailable: true` to hide it instead, or `default:` to show a placeholder value.
 
+A `timer` entity shows its remaining time rather than its raw state: the localized state while idle, a counting `mm:ss` while
+running, and `mm:ss (Paused)` when paused. An explicit `attribute:` or `template:` overrides this.
+
 | Name              | Type        | Default                     | Description                                                        |
 | ----------------- | ----------- | --------------------------- | ------------------------------------------------------------------ |
 | entity            | string      |                             | A valid entity_id (or skip to use main entity)                     |

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import {
 } from './templates';
 import { style } from './styles';
 import './editor';
+import './timer_remaining';
 
 // hui-generic-entity-row attaches its own tap/hold/double-tap detection to the outer row
 // element unconditionally (see the catchInteraction comment in render() below) via mousedown/
@@ -360,6 +361,16 @@ class MultipleEntityRow extends LitElement {
         if (config.template !== undefined) {
             const value = hasTemplate(config.template) ? '' : config.template;
             return `${value}${config.unit ? ` ${config.unit}` : ''}`;
+        }
+        // A timer's raw state is just active/idle/paused, which is rarely what anyone wants to
+        // see - HA's own timer row shows the countdown instead (see #65, #299, #350). Automatic
+        // for the timer domain, but only for the state itself: an explicit attribute or template
+        // above still wins, and an idle timer falls through to its localized state anyway.
+        if (!config.attribute && stateObj.entity_id?.startsWith('timer.')) {
+            return html`<multiple-entity-row-timer
+                .hass=${this._hass}
+                .stateObj=${stateObj}
+            ></multiple-entity-row-timer>`;
         }
         const isLastChangedAttr = config.attribute && [LAST_CHANGED, LAST_UPDATED].includes(config.attribute);
         // A configured timestamp format wins over the default relative-time widget for the

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -173,6 +173,46 @@ describe('multiple-entity-row', () => {
         expect(el.shadowRoot.innerHTML).toContain('n/a');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/65, #299 and #350 - a
+    // timer's raw state is only active/idle/paused, so the countdown is shown instead.
+    describe('timer entities', () => {
+        const timerHass = (state, attributes) =>
+            buildHass({
+                'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} },
+                'timer.kitchen': { entity_id: 'timer.kitchen', state, attributes },
+            });
+
+        it('renders the countdown instead of the raw state', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'timer.kitchen' }] });
+            el.hass = timerHass('paused', { remaining: '00:01:30' });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('multiple-entity-row-timer')).not.toBeNull();
+            expect(el.shadowRoot.innerHTML).not.toContain('paused<');
+        });
+
+        it('works for the main state too', async () => {
+            el.setConfig({ entity: 'timer.kitchen' });
+            el.hass = timerHass('paused', { remaining: '00:01:30' });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('.entity.state multiple-entity-row-timer')).not.toBeNull();
+        });
+
+        // An explicit attribute or template is a deliberate choice and must not be overridden.
+        it('leaves an explicit attribute alone', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'timer.kitchen', attribute: 'duration' }] });
+            el.hass = timerHass('active', { remaining: '00:01:30', duration: '00:05:00' });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('multiple-entity-row-timer')).toBeNull();
+        });
+
+        it('leaves a non-timer entity alone', async () => {
+            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.main' }] });
+            el.hass = timerHass('idle', {});
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('multiple-entity-row-timer')).toBeNull();
+        });
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/364 - a removed or renamed
     // entity id used to vanish from the row with no clue which slot it was.
     describe('missing entity', () => {

--- a/src/lib/timer.js
+++ b/src/lib/timer.js
@@ -1,0 +1,35 @@
+// Source: https://github.com/home-assistant/frontend/blob/dev/src/data/timer.ts
+//
+// Vendored rather than reusing HA's <ha-timer-remaining-time>: that element lives in a lazily
+// loaded chunk, so it is only defined once a native timer row or more-info dialog has rendered.
+// A dashboard built solely from our rows may never load it, and an undefined custom element
+// renders blank (see #65, #299, #350).
+
+import { secondsToDuration } from './seconds_to_duration';
+
+const durationToSeconds = (duration) => {
+    const parts = duration.split(':').map(Number);
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+};
+
+/** Seconds left on a timer, or undefined when it has none. Counts down from `finishes_at` while
+ * running, since `remaining` is only refreshed on state changes. */
+export const timerTimeRemaining = (stateObj) => {
+    if (!stateObj.attributes.remaining) {
+        return undefined;
+    }
+    if (stateObj.state === 'active') {
+        const finishes = new Date(stateObj.attributes.finishes_at).getTime();
+        return Math.max((finishes - Date.now()) / 1000, 0);
+    }
+    return durationToSeconds(stateObj.attributes.remaining);
+};
+
+/** Idle (or finished) shows the localized state; running shows the countdown; paused shows both. */
+export const computeDisplayTimer = (hass, stateObj, timeRemaining) => {
+    if (stateObj.state === 'idle' || timeRemaining === 0) {
+        return hass.formatEntityState(stateObj);
+    }
+    const display = secondsToDuration(timeRemaining || 0) ?? '0';
+    return stateObj.state === 'paused' ? `${display} (${hass.formatEntityState(stateObj)})` : display;
+};

--- a/src/lib/timer.test.js
+++ b/src/lib/timer.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeDisplayTimer, timerTimeRemaining } from './timer';
+
+const hass = { formatEntityState: vi.fn((stateObj) => `localized:${stateObj.state}`) };
+
+const timer = (state, attributes) => ({ entity_id: 'timer.test', state, attributes });
+
+describe('timerTimeRemaining', () => {
+    it('is undefined for a timer with no remaining attribute', () => {
+        expect(timerTimeRemaining(timer('idle', {}))).toBeUndefined();
+    });
+
+    // `remaining` is only refreshed on state changes, so a running timer has to be counted down
+    // from finishes_at or it would sit still between updates.
+    it('counts down from finishes_at while active', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-06T12:00:00Z'));
+        const stateObj = timer('active', { remaining: '00:05:00', finishes_at: '2026-08-06T12:02:00.000Z' });
+        expect(timerTimeRemaining(stateObj)).toBe(120);
+        vi.advanceTimersByTime(30_000);
+        expect(timerTimeRemaining(stateObj)).toBe(90);
+        vi.useRealTimers();
+    });
+
+    it('never goes negative once finishes_at has passed', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-06T12:05:00Z'));
+        const stateObj = timer('active', { remaining: '00:05:00', finishes_at: '2026-08-06T12:00:00.000Z' });
+        expect(timerTimeRemaining(stateObj)).toBe(0);
+        vi.useRealTimers();
+    });
+
+    // A paused timer is frozen, so the stored value is the truth.
+    it('uses the stored remaining when paused', () => {
+        expect(timerTimeRemaining(timer('paused', { remaining: '00:01:30' }))).toBe(90);
+    });
+});
+
+describe('computeDisplayTimer', () => {
+    it('shows the localized state when idle', () => {
+        expect(computeDisplayTimer(hass, timer('idle', {}), undefined)).toBe('localized:idle');
+    });
+
+    it('shows the localized state when the countdown reaches zero', () => {
+        expect(computeDisplayTimer(hass, timer('active', {}), 0)).toBe('localized:active');
+    });
+
+    it('shows the countdown while running', () => {
+        expect(computeDisplayTimer(hass, timer('active', {}), 90)).toBe('1:30');
+        expect(computeDisplayTimer(hass, timer('active', {}), 3661)).toBe('1:01:01');
+    });
+
+    it('appends the localized state when paused', () => {
+        expect(computeDisplayTimer(hass, timer('paused', {}), 90)).toBe('1:30 (localized:paused)');
+    });
+});

--- a/src/timer_remaining.js
+++ b/src/timer_remaining.js
@@ -1,0 +1,69 @@
+import { LitElement, html } from 'lit';
+
+import { computeDisplayTimer, timerTimeRemaining } from './lib/timer';
+
+// A timer's countdown has to advance without any hass update to trigger it, which the row itself
+// cannot do: its shouldUpdate gate (hasConfigOrEntitiesChanged) returns false when no watched
+// state changed, so a requestUpdate on the row every second would simply be swallowed. Keeping
+// the interval in its own element sidesteps that gate and re-renders only the countdown text
+// rather than the whole row.
+//
+// Modelled on HA's <ha-timer-remaining-time>, including the important part: the interval only
+// runs while the timer is actually counting down. Idle and paused timers cost nothing, and the
+// interval is cleared whenever the element leaves the DOM.
+class TimerRemaining extends LitElement {
+    static get properties() {
+        return {
+            hass: { attribute: false },
+            stateObj: { attribute: false },
+            _remaining: { state: true },
+        };
+    }
+
+    // Light DOM, so the row's own styles apply to the text as they would to any other value.
+    createRenderRoot() {
+        return this;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._startInterval();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._clearInterval();
+    }
+
+    willUpdate(changedProps) {
+        // A new state object means the timer was started, paused or cancelled - recompute now and
+        // start or stop ticking to match.
+        if (changedProps.has('stateObj')) {
+            this._startInterval();
+        }
+    }
+
+    _clearInterval() {
+        if (this._interval) {
+            clearInterval(this._interval);
+            this._interval = undefined;
+        }
+    }
+
+    _startInterval() {
+        this._clearInterval();
+        this._remaining = this.stateObj ? timerTimeRemaining(this.stateObj) : undefined;
+        if (this.stateObj?.state === 'active') {
+            this._interval = setInterval(() => {
+                this._remaining = timerTimeRemaining(this.stateObj);
+            }, 1000);
+        }
+    }
+
+    render() {
+        if (!this.hass || !this.stateObj) return html``;
+        return html`${computeDisplayTimer(this.hass, this.stateObj, this._remaining)}`;
+    }
+}
+
+customElements.define('multiple-entity-row-timer', TimerRemaining);

--- a/src/timer_remaining.test.js
+++ b/src/timer_remaining.test.js
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import './timer_remaining';
+
+const flushRender = async (el) => {
+    await el.updateComplete;
+    await el.updateComplete;
+};
+
+const hass = { formatEntityState: vi.fn((stateObj) => `localized:${stateObj.state}`) };
+
+const timer = (state, attributes) => ({ entity_id: 'timer.test', state, attributes });
+
+describe('multiple-entity-row-timer', () => {
+    let el;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-06T12:00:00Z'));
+        el = document.createElement('multiple-entity-row-timer');
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        el.remove();
+        vi.useRealTimers();
+    });
+
+    it('renders the countdown and advances it once a second', async () => {
+        el.hass = hass;
+        el.stateObj = timer('active', { remaining: '00:02:00', finishes_at: '2026-08-06T12:02:00.000Z' });
+        await flushRender(el);
+        expect(el.textContent).toBe('2:00');
+
+        vi.advanceTimersByTime(1000);
+        await flushRender(el);
+        expect(el.textContent).toBe('1:59');
+    });
+
+    // The tick is the whole cost of this feature, so it must only run while counting down.
+    it('does not tick while idle or paused', async () => {
+        el.hass = hass;
+        el.stateObj = timer('paused', { remaining: '00:01:30' });
+        await flushRender(el);
+        expect(el.textContent).toBe('1:30 (localized:paused)');
+        expect(vi.getTimerCount()).toBe(0);
+
+        el.stateObj = timer('idle', {});
+        await flushRender(el);
+        expect(el.textContent).toBe('localized:idle');
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('starts ticking when the timer becomes active and stops when it does not', async () => {
+        el.hass = hass;
+        el.stateObj = timer('idle', {});
+        await flushRender(el);
+        expect(vi.getTimerCount()).toBe(0);
+
+        el.stateObj = timer('active', { remaining: '00:01:00', finishes_at: '2026-08-06T12:01:00.000Z' });
+        await flushRender(el);
+        expect(vi.getTimerCount()).toBe(1);
+
+        el.stateObj = timer('paused', { remaining: '00:00:30' });
+        await flushRender(el);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears its interval when removed from the DOM', async () => {
+        el.hass = hass;
+        el.stateObj = timer('active', { remaining: '00:01:00', finishes_at: '2026-08-06T12:01:00.000Z' });
+        await flushRender(el);
+        expect(vi.getTimerCount()).toBe(1);
+
+        el.remove();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
A timer's raw state is only `active`/`idle`/`paused`, so the row now shows the countdown instead: the localized state while idle, `mm:ss` while running, and `mm:ss (Paused)` when paused — matching HA's own timer row. An explicit `attribute:` or `template:` still wins.

HA's `<ha-timer-remaining-time>` is deliberately not reused. It lives in a lazily-loaded chunk and is only defined once a native timer row or more-info dialog has rendered, so a dashboard built solely from these rows may never load it, and an undefined custom element renders blank. The ~30 lines behind it are vendored instead, next to `seconds_to_duration`, which was already vendored and identical to HA's.

The countdown gets its own element because the row can't drive it: `shouldUpdate` returns false when no watched state changed, so ticking via `requestUpdate()` on the row would be swallowed. The element also keeps the repaint to the countdown text rather than the whole row.

The interval only runs while the timer is active and is cleared on state change and on disconnect — that's the entire cost of the feature, and tests assert no timers remain when idle, paused or removed from the DOM.

Refs #65, #299, #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)