### PR TITLE
Free the name's space and add vertical alignment (#341, #365, #261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file.
 - `vars` - named values usable in any template in the same scope, on the row and on additional entities, which inherit the row's and may shadow them. Values may themselves be templates, and a variable can build on one declared before it. Inlined into each template that uses them, so a field is still a single subscription (#422)
 - Templates inside `tap_action`/`hold_action`/`double_tap_action`, at any depth - service data, `target`, `navigation_path`, `confirmation.text`. Results keep their native type, and are resolved when the action fires so a service call carries current values (#422)
 - An additional entity no longer needs `entity`, `attribute` or `icon` - an entry with none of them (even `- {}`) shows the main entity's state, which is the only way to repeat it when the id isn't known in advance, as under `custom:auto-entities` (#340)
+- `align` option - vertical alignment of the entity slots (`top`, `center` or `bottom`). The `styles` option can't do this: it reaches one entity's own div, which is a flex item, where `vertical-align` has no effect (#261)
 - Timer entities show their remaining time instead of the raw `active`/`idle`/`paused` state - the localized state while idle, a counting `mm:ss` while running, and `mm:ss (Paused)` when paused, matching HA's own timer row. An explicit `attribute:` or `template:` still wins (#65, #299, #350)
 
 **Changed:**
+- `name: false` now removes the name entirely rather than blanking it, so the entities get its space. Rows that also set `secondary_info` keep the name area, since HA renders secondary info inside it (#341, #365)
 - An entity id that doesn't resolve is now marked with a warning icon instead of silently disappearing from the row. `hide_unavailable: true` hides it as before, and `default:` still takes precedence (#364)
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | type             | string      | **Required**                | `custom:multiple-entity-row`                     |
 | entity           | string      | **Required**                | Entity ID (`domain.my_entity_id`)                |
 | attribute        | string      |                             | Show an attribute instead of the state value     |
-| name             | string/bool | `friendly_name`             | Override entity friendly name                    |
+| name             | string/bool | `friendly_name`             | Override name; `false` also frees its space      |
 | unit             | string/bool | `unit_of_measurement`       | Override entity unit of measurement              |
 | icon             | string      | `icon`                      | Override entity icon or image                    |
 | icon_color       | string      |                             | CSS color for the entity icon                    |
@@ -61,6 +61,7 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | state_color      | bool        | _deprecated_                | Superseded by `color`                            |
 | column           | bool        | `false`                     | Show entities in a column instead of a row       |
 | wrap             | bool        | `false`                     | Wrap onto multiple lines instead of overflowing  |
+| align            | string      | `center`                    | Vertical alignment: `top`, `center` or `bottom`  |
 | default          | string      |                             | Display this value when the state is hidden      |
 | hide_unavailable | bool        | `false`                     | Hide the state value if unavailable              |
 | hide_if          | object/any  | _[Hiding](#hiding)_         | Hide the state value if criteria match           |

--- a/src/editor.test.ts
+++ b/src/editor.test.ts
@@ -73,6 +73,24 @@ describe('multiple-entity-row-editor', () => {
             (el as any)._mainValueChanged({ detail: { value: { entity: 'sensor.main', unit: 'false' } } });
             expect(configs[0].unit).toBe(false);
         });
+
+        // `name: false` hides the name (and frees its space) but is otherwise unreachable from a
+        // text selector, so it round-trips the same way as unit (see #341, #365).
+        it('round-trips name: false through the text form as the string "false"', () => {
+            setConfig({ entity: 'sensor.main', name: false });
+            expect((el as any)._mainFormData().name).toBe('false');
+
+            (el as any)._mainValueChanged({ detail: { value: { entity: 'sensor.main', name: 'false' } } });
+            expect(configs[0].name).toBe(false);
+        });
+
+        it('leaves an ordinary name untouched', () => {
+            setConfig({ entity: 'sensor.main', name: 'Kitchen' });
+            expect((el as any)._mainFormData().name).toBe('Kitchen');
+
+            (el as any)._mainValueChanged({ detail: { value: { entity: 'sensor.main', name: 'Kitchen' } } });
+            expect(configs[0].name).toBe('Kitchen');
+        });
     });
 
     describe('additional entities', () => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -107,14 +107,17 @@ const parseStylesText = (text: string): Record<string, string> => {
     return result;
 };
 
-/** `unit: false` (hide the unit) is a boolean in YAML but must round-trip through ha-form's text
- * selector - map it to/from the literal string 'false'. Side benefit: typing "false" into the
- * unit field sets the boolean form from the editor. */
-const unitToForm = <T extends Record<string, any>>(config: T): T =>
-    config.unit === false ? { ...config, unit: 'false' } : config;
+/** `unit: false` (hide the unit) and `name: false` (hide the name) are booleans in YAML, but
+ * ha-form's text selectors can only produce strings - so they round-trip through the literal
+ * string 'false'. Side benefit: typing "false" into either field sets the boolean from the
+ * editor, which is otherwise unreachable there. */
+const FALSE_KEYS = ['unit', 'name'];
 
-const unitFromForm = <T extends Record<string, any>>(config: T): T =>
-    config.unit === 'false' ? { ...config, unit: false } : config;
+const falseToForm = <T extends Record<string, any>>(config: T): T =>
+    FALSE_KEYS.reduce((acc, key) => (acc[key] === false ? { ...acc, [key]: 'false' } : acc), config);
+
+const falseFromForm = <T extends Record<string, any>>(config: T): T =>
+    FALSE_KEYS.reduce((acc, key) => (acc[key] === 'false' ? { ...acc, [key]: false } : acc), config);
 
 // Our own clipboard slot. Deliberately NOT HA's `dashboardCardClipboard` - that one holds
 // Lovelace card configs and is consumed by <hui-card-picker>; pasting an entity sub-config
@@ -733,7 +736,7 @@ export class MultipleEntityRowEditor extends LitElement {
             <div class="child-editor">
                 <ha-form
                     .hass=${this.hass}
-                    .data=${this._formatToForm(`sub-${additionalIndex}`, unitToForm(entityConfig))}
+                    .data=${this._formatToForm(`sub-${additionalIndex}`, falseToForm(entityConfig))}
                     .schema=${ADDITIONAL_TAB_SCHEMA}
                     .computeLabel=${this._computeLabel}
                     @value-changed=${(ev: CustomEvent) => this._additionalValueChanged(ev, additionalIndex)}
@@ -744,7 +747,7 @@ export class MultipleEntityRowEditor extends LitElement {
                 <div class="section-label">Interactions</div>
                 <ha-form
                     .hass=${this.hass}
-                    .data=${this._formatToForm(`sub-${additionalIndex}`, unitToForm(entityConfig))}
+                    .data=${this._formatToForm(`sub-${additionalIndex}`, falseToForm(entityConfig))}
                     .schema=${ACTIONS_SCHEMA}
                     .computeLabel=${this._computeLabel}
                     @value-changed=${(ev: CustomEvent) => this._additionalValueChanged(ev, additionalIndex)}
@@ -774,12 +777,12 @@ export class MultipleEntityRowEditor extends LitElement {
     /** Form data for the Main tab: seeds show_state's runtime default (ON) so the toggle reads
      * correctly for configs that don't set the key, and maps `unit: false` to its text form. */
     private _mainFormData(): MultipleEntityRowConfig {
-        return this._formatToForm('main', unitToForm({ show_state: true, ...this._config! }));
+        return this._formatToForm('main', falseToForm({ show_state: true, ...this._config! }));
     }
 
     private _mainValueChanged = (ev: CustomEvent): void => {
         if (!this._config) return;
-        let newConfig = unitFromForm({ ...(ev.detail.value as MultipleEntityRowConfig) });
+        let newConfig = falseFromForm({ ...(ev.detail.value as MultipleEntityRowConfig) });
         newConfig = this._formatFromForm('main', newConfig, this._config.format);
         // show_state: true is the seeded runtime default - strip the redundant key on the way
         // back out so it doesn't pollute the YAML.
@@ -794,7 +797,7 @@ export class MultipleEntityRowEditor extends LitElement {
         const oldFormat = isObject(raw) ? (raw as EntityConfig).format : undefined;
         entities[additionalIndex] = this._formatFromForm(
             `sub-${additionalIndex}`,
-            unitFromForm(ev.detail.value as EntityConfig),
+            falseFromForm(ev.detail.value as EntityConfig),
             oldFormat
         );
         this._updateConfig({ entities });
@@ -926,7 +929,7 @@ export class MultipleEntityRowEditor extends LitElement {
                     ? html`<div class="secondary-sub-form">
                           <ha-form
                               .hass=${this.hass}
-                              .data=${this._formatToForm('secondary', unitToForm(si as EntityConfig))}
+                              .data=${this._formatToForm('secondary', falseToForm(si as EntityConfig))}
                               .schema=${ADDITIONAL_TAB_SCHEMA}
                               .computeLabel=${this._computeLabel}
                               @value-changed=${this._secondaryEntityChanged}
@@ -977,7 +980,11 @@ export class MultipleEntityRowEditor extends LitElement {
             ? (this._config!.secondary_info as EntityConfig).format
             : undefined;
         this._updateConfig({
-            secondary_info: this._formatFromForm('secondary', unitFromForm(ev.detail.value as EntityConfig), oldFormat),
+            secondary_info: this._formatFromForm(
+                'secondary',
+                falseFromForm(ev.detail.value as EntityConfig),
+                oldFormat
+            ),
         });
     };
 

--- a/src/editor_schemas.ts
+++ b/src/editor_schemas.ts
@@ -129,8 +129,8 @@ export const ADDITIONAL_TAB_SCHEMA = [
 export const LABELS: Record<string, string> = {
     entity: 'Entity',
     attribute: 'Attribute',
-    name: 'Name override',
-    unit: 'Unit',
+    name: 'Name override (or false to hide)',
+    unit: 'Unit (or false to hide)',
     icon: 'Icon',
     icon_color: 'Icon color (CSS value, e.g. red, #ff0000, var(--my-color))',
     image: 'Image URL',

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,11 @@ const blankName = (text) => (typeof text === 'string' && text.trim() === '' ? nu
 // would make any row with an icon skip the placeholder for a perfectly ordinary text state.
 const rendersControl = (config) => config.toggle === true || !!config.icon || isObject(config.state_icon);
 
+// Entities are flex items, so vertical alignment belongs on their container - `styles` only
+// reaches one entity's own div, where vertical-align does nothing (see #261). `center` is the
+// default and needs no class.
+const ALIGN_CLASSES = { top: 'align-top', bottom: 'align-bottom' };
+
 console.info(
     `%c MULTIPLE-ENTITY-ROW %c ${process.env.PACKAGE_VERSION} (built ${process.env.BUILD_TIME}, ${process.env.BUILD_COMMIT}) `,
     'color: cyan; background: black; font-weight: bold;',
@@ -113,6 +118,10 @@ class MultipleEntityRow extends LitElement {
         // semantics (see #386). That migration only touches the top-level row config, not our
         // own nested `entities`/`secondary_info` config, so this fallback only needs to happen
         // here. Prefer `format` if somehow both are present (e.g. a value hand-edited back in).
+        // Remembered before the normalization below erases it: `name: false` should remove HA's
+        // name box entirely rather than blank it (see hideName in render).
+        this._nameHidden = config.name === false;
+
         this.config = {
             ...config,
             name: config.name === false ? ' ' : config.name,
@@ -187,18 +196,28 @@ class MultipleEntityRow extends LitElement {
         // across the row up to 4.6.1 and stopped in 4.7.0 when this was flipped to true (see
         // #411). Keeping the bare slot also keeps .entities-row as the flex item, which is the
         // only reason our own CSS (wrap, shrinking) can affect overflow at all.
+        // `name: false` used to be blanked to a space, which left HA's name box in place taking
+        // its flex: 1 1 30% share; hideName drops the box so the entities get that width back
+        // (see #341, #365). HA renders secondary info inside that same box, though, so only hide
+        // it when there is no secondary info to lose.
+        const hideName = this._nameHidden && !this.config.secondary_info;
         return html`<hui-generic-entity-row
             style="${iconColorCss(config.icon_color)}"
             .hass="${this._hass}"
             .config="${rowConfig}"
             .secondaryText="${this.renderSecondaryInfo()}"
+            .hideName=${hideName}
             .catchInteraction=${false}
         >
             <div
-                class="${this.config.column ? 'entities-column' : 'entities-row'}${!this.config.column &&
-                this.config.wrap
-                    ? ' wrap'
-                    : ''}"
+                class="${[
+                    this.config.column ? 'entities-column' : 'entities-row',
+                    !this.config.column && this.config.wrap ? 'wrap' : '',
+                    ALIGN_CLASSES[this.config.align] ?? '',
+                    hideName ? 'no-name' : '',
+                ]
+                    .filter(Boolean)
+                    .join(' ')}"
             >
                 ${this.config.show_state_first
                     ? html`${this.renderMainEntity()}${this.entities.map((entity, index) =>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -173,6 +173,80 @@ describe('multiple-entity-row', () => {
         expect(el.shadowRoot.innerHTML).toContain('n/a');
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/341 and #365 - blanking
+    // the name left HA's name box in place taking its flex share; hideName removes the box so
+    // the entities get that width.
+    describe('hidden name', () => {
+        const hassWithMain = () =>
+            buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+        const rowFor = async (config) => {
+            el.setConfig({ entity: 'sensor.main', ...config });
+            el.hass = hassWithMain();
+            await flushRender(el);
+            return el.shadowRoot.querySelector('hui-generic-entity-row');
+        };
+
+        it('hides the name box for name: false', async () => {
+            expect((await rowFor({ name: false })).hideName).toBe(true);
+        });
+
+        it('keeps the name box for a normal name', async () => {
+            expect((await rowFor({ name: 'Kitchen' })).hideName).toBe(false);
+        });
+
+        // The name box is also what pushes the entities right (it grows at flex: 1 1 30%), so
+        // removing it has to hand that job over or they end up against the icon.
+        it('keeps the entities right-aligned once the name box is gone', async () => {
+            await rowFor({ name: false });
+            expect(el.shadowRoot.querySelector('.entities-row').classList.contains('no-name')).toBe(true);
+        });
+
+        it('adds no such class while the name box remains', async () => {
+            await rowFor({ name: 'Kitchen' });
+            expect(el.shadowRoot.querySelector('.entities-row').classList.contains('no-name')).toBe(false);
+        });
+
+        // HA renders secondary info inside the same box, so hiding it would silently take the
+        // secondary text with it.
+        it('keeps the name box when secondary info would be lost', async () => {
+            expect((await rowFor({ name: false, secondary_info: 'last-changed' })).hideName).toBe(false);
+            expect((await rowFor({ name: false, secondary_info: { entity: 'sensor.main' } })).hideName).toBe(false);
+        });
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/261 - entity slots are
+    // flex items, so vertical alignment has to be set on their container.
+    describe('align', () => {
+        const containerFor = async (config) => {
+            el.setConfig({ entity: 'sensor.main', entities: ['sensor.main'], ...config });
+            el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+            await flushRender(el);
+            return el.shadowRoot.querySelector('.entities-row, .entities-column');
+        };
+
+        it('adds no class by default', async () => {
+            const row = await containerFor({});
+            expect(row.classList.contains('align-top')).toBe(false);
+            expect(row.classList.contains('align-bottom')).toBe(false);
+        });
+
+        it('aligns top and bottom', async () => {
+            expect((await containerFor({ align: 'top' })).classList.contains('align-top')).toBe(true);
+            expect((await containerFor({ align: 'bottom' })).classList.contains('align-bottom')).toBe(true);
+        });
+
+        it('ignores an unknown value rather than emitting a stray class', async () => {
+            const row = await containerFor({ align: 'sideways' });
+            expect(row.className).toBe('entities-row');
+        });
+
+        it('applies to a column layout too', async () => {
+            const row = await containerFor({ column: true, align: 'bottom' });
+            expect(row.classList.contains('entities-column')).toBe(true);
+            expect(row.classList.contains('align-bottom')).toBe(true);
+        });
+    });
+
     // See https://github.com/benct/lovelace-multiple-entity-row/issues/65, #299 and #350 - a
     // timer's raw state is only active/idle/paused, so the countdown is shown instead.
     describe('timer entities', () => {

--- a/src/styles.js
+++ b/src/styles.js
@@ -30,6 +30,23 @@ export const style = (css) => css`
         justify-content: space-between;
         align-items: center;
     }
+    /* HA's name box is what pushes the entities to the right: it grows at flex: 1 1 30%. Hiding
+       it removes that push too, leaving them against the icon, so take over the job here - the
+       point of hiding the name is more room, not a different alignment (see #341, #365). */
+    .entities-row.no-name,
+    .entities-column.no-name {
+        margin-left: auto;
+    }
+    /* The 'styles' option reaches one entity's div, which is a flex item - so vertical-align
+       there does nothing and alignment has to be set on the container instead (see #261). */
+    .entities-row.align-top,
+    .entities-column.align-top {
+        align-items: flex-start;
+    }
+    .entities-row.align-bottom,
+    .entities-column.align-bottom {
+        align-items: flex-end;
+    }
     .entities-row .entity {
         margin-right: 16px;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,8 @@ export interface MultipleEntityRowConfig extends EntityOptions {
     image?: string;
     column?: boolean;
     wrap?: boolean;
+    // Vertical alignment of the entity slots: "top" | "center" (default) | "bottom".
+    align?: string;
     // HA 2026.7+'s row editor renames `format` to `time_format` on save (see #386).
     time_format?: string;
     entities?: (string | EntityConfig)[];


### PR DESCRIPTION
`name: false` was blanked to a single space, which left HA's name box in place still taking its `flex: 1 1 30%` share. It now sets `hideName` so the box is dropped and the entities get that width — except when `secondary_info` is configured, since HA renders secondary info inside that same box and hiding it would take the secondary text along.

That box is also what pushes the entities to the right, so removing it left them against the icon; the container takes over with `margin-left: auto`. Reclaiming the name's space was the point, not changing the alignment.

Adds `align` (`top`/`center`/`bottom`) for the entity slots. `styles` can't do this: it reaches one entity's own div, which is a flex item, where `vertical-align` has no effect — alignment belongs on the container.

The editor couldn't express either boolean, so `name` joins `unit` in round-tripping through the literal string `'false'`, and both labels now say so; that affordance was undiscoverable before.

The icon's own 40px is not reclaimable: `state-badge{flex:0 0 40px}` is hardcoded in `hui-generic-entity-row`'s stylesheet, inside HA's shadow root, with no custom property and no conditional. That half of #341/#365 stays card-mod territory.

Refs #341, #365, #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)