### PR TITLE
Make inter-entity gaps clickable (#432)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ multiple-entity-row.js.gz
 coverage/
 .dev/ha-config/
 .dev/conversation*
+.claude/settings.local.json

--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,10 @@ class MultipleEntityRow extends LitElement {
         // catchInteraction must stay false: despite the name it does NOT control whether
         // hui-generic-entity-row handles interaction (its actionHandler is bound to the .row
         // wrapper unconditionally - that was the #338 root cause, and what actually protects us
-        // is stopBubble on each entity element). All it selects is the markup around our slot:
+        // is stopBubble on each entity element; since ~HA 2026.8 the false-branch slot also
+        // stops click/touchend/keydown/action itself, making slotted clicks inert to the row -
+        // which is why inter-entity gaps must be clickable padding, not margin, see #432).
+        // All it selects beyond that is the markup around our slot:
         // false yields a bare <slot>, true wraps it in `.text-content.value > .state`. Those two
         // extra boxes are shrink-to-fit, so they pin our row to its own content width and break
         // any `width: 100%` / justify-content styling users apply to .entities-row - it spread

--- a/src/styles.js
+++ b/src/styles.js
@@ -47,11 +47,14 @@ export const style = (css) => css`
     .entities-column.align-bottom {
         align-items: flex-end;
     }
+    /* Padding, not margin: the row's cursor:pointer inherits into the gap, but HA stops slotted
+       clicks at the bare slot (catchInteraction=false), so a margin gap is dead space that looks
+       clickable. Padding keeps it inside the entity's own click target (see #432). */
     .entities-row .entity {
-        margin-right: 16px;
+        padding-right: 16px;
     }
     .entities-row .entity:last-of-type {
-        margin-right: 0;
+        padding-right: 0;
     }
     /* Opt-in, because it trades a taller row for not overflowing: nothing between HA's .row and
        our entities can shrink, so a row needing more width than the card has just spills past

--- a/src/styles.test.js
+++ b/src/styles.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { style } from './styles';
+
+// jsdom can't do layout, so pin the mechanism at the source level instead.
+const cssText = style((strings, ...values) => strings.reduce((out, s, i) => out + s + (values[i] ?? ''), ''));
+
+describe('entity spacing', () => {
+    // The inter-entity gap must be padding, not margin: HA's row shows cursor:pointer over the
+    // gap but stops slotted clicks at the slot, so a margin gap is dead space that looks
+    // clickable. Padding keeps the gap inside the entity's click target (see #432).
+    it('uses padding so the gap stays clickable', () => {
+        expect(cssText).toMatch(/\.entities-row \.entity \{[^}]*padding-right: 16px/);
+        expect(cssText).not.toMatch(/margin-right: 16px/);
+    });
+});


### PR DESCRIPTION
Fixes #432.

The 16px `margin-right` between entities shows the row's pointer cursor but is dead space — since ~HA 2026.8, `hui-generic-entity-row` stops slotted clicks at the bare slot (`catchInteraction=false`), so a gap click can't even fire the row action. Switching to `padding-right` puts the gap inside the entity's own click target; rendered layout is unchanged.

Verified on the docker testbed (HA 2026.8.0): gap click now fires the adjacent entity's action, layout pixel-identical. One visible side effect: per-entity `styles:` backgrounds/borders now paint across the 16px gap, since padding is inside the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)