### PR TITLE
Fix 4.10.1 gap regression and center toggles (#432, #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 **Fixed:**
 - 4.10.1 made the inter-entity gap padding, which stacked with margins users set via `styles` and widened tuned rows into overflowing on narrow screens. Spacing is margin again (layout identical to 4.10.0); the gap stays clickable through a layout-neutral hit-area extension (#432)
+- Toggles are now centered within their entity slot; HA's toggle host left-aligns in any slot wider than the switch (#436)
 
 ## 4.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 4.10.2
+
+**Fixed:**
+- 4.10.1 made the inter-entity gap padding, which stacked with margins users set via `styles` and widened tuned rows into overflowing on narrow screens. Spacing is margin again (layout identical to 4.10.0); the gap stays clickable through a layout-neutral hit-area extension (#432)
+
 ## 4.10.1
 
 **Fixed:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-entity-row",
-  "version": "4.10.1",
+  "version": "4.10.2-beta.1",
   "description": "Show multiple entity states, attributes and icons on entity rows in Home Assistant's Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/styles.js
+++ b/src/styles.js
@@ -71,6 +71,13 @@ export const style = (css) => css`
         right: -16px;
         width: 16px;
     }
+    /* HA's ha-entity-toggle host is display:flex with no horizontal alignment, so in a slot
+       wider than the switch it hugs the left edge while everything else centers. Outer styles
+       out-rank :host rules, so it can be centered from here; keeping the host's flex box (vs
+       display:contents) preserves the full-width tap strip and HA's box assumptions (#436). */
+    .entity ha-entity-toggle {
+        justify-content: center;
+    }
     /* Opt-in, because it trades a taller row for not overflowing: nothing between HA's .row and
        our entities can shrink, so a row needing more width than the card has just spills past
        the edge (worst on narrow phone screens - see #411). Wrapping reflows instead. */

--- a/src/styles.js
+++ b/src/styles.js
@@ -47,14 +47,29 @@ export const style = (css) => css`
     .entities-column.align-bottom {
         align-items: flex-end;
     }
-    /* Padding, not margin: the row's cursor:pointer inherits into the gap, but HA stops slotted
-       clicks at the bare slot (catchInteraction=false), so a margin gap is dead space that looks
-       clickable. Padding keeps it inside the entity's own click target (see #432). */
+    /* The 16px gap must be margin, not padding: users tune spacing with their own margins in
+       the 'styles' option, which replace this margin but would stack on top of a padding - 4.10.1 did
+       padding and widened every tuned row into overflowing on phones (see #432). The gap still
+       has to be clickable though: the row's cursor:pointer inherits into it, but HA stops
+       slotted clicks at the bare slot (catchInteraction=false), so bare margin is dead space
+       that looks clickable. The ::after extension puts the gap inside the entity's hit area
+       without affecting layout. position:relative on every entity keeps hit-testing fair: a
+       positioned later sibling beats its neighbor's ::after wherever a user's zero/negative
+       margin makes them overlap, so no entity steals its neighbor's clicks. */
     .entities-row .entity {
-        padding-right: 16px;
+        margin-right: 16px;
+        position: relative;
     }
     .entities-row .entity:last-of-type {
-        padding-right: 0;
+        margin-right: 0;
+    }
+    .entities-row .entity:not(:last-of-type)::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: -16px;
+        width: 16px;
     }
     /* Opt-in, because it trades a taller row for not overflowing: nothing between HA's .row and
        our entities can shrink, so a row needing more width than the card has just spills past

--- a/src/styles.test.js
+++ b/src/styles.test.js
@@ -5,11 +5,18 @@ import { style } from './styles';
 const cssText = style((strings, ...values) => strings.reduce((out, s, i) => out + s + (values[i] ?? ''), ''));
 
 describe('entity spacing', () => {
-    // The inter-entity gap must be padding, not margin: HA's row shows cursor:pointer over the
-    // gap but stops slotted clicks at the slot, so a margin gap is dead space that looks
-    // clickable. Padding keeps the gap inside the entity's click target (see #432).
-    it('uses padding so the gap stays clickable', () => {
-        expect(cssText).toMatch(/\.entities-row \.entity \{[^}]*padding-right: 16px/);
-        expect(cssText).not.toMatch(/margin-right: 16px/);
+    // Margin, not padding: user `styles` margins replace this margin, but stacked on top of a
+    // padding gap - the 4.10.1 regression that overflowed tuned rows on phones (see #432).
+    it('uses margin so user style margins replace it instead of stacking', () => {
+        expect(cssText).toMatch(/\.entities-row \.entity \{[^}]*margin-right: 16px/);
+        expect(cssText).not.toMatch(/padding-right: 16px/);
+    });
+
+    // The margin gap is dead space to HA (slotted clicks stop at the slot), so each entity's
+    // hit area must be extended across it without affecting layout (see #432).
+    it('extends the hit area across the gap with a layout-neutral pseudo-element', () => {
+        expect(cssText).toMatch(/\.entities-row \.entity:not\(:last-of-type\)::after/);
+        expect(cssText).toMatch(/right: -16px/);
+        expect(cssText).toMatch(/\.entities-row \.entity \{[^}]*position: relative/);
     });
 });

--- a/src/styles.test.js
+++ b/src/styles.test.js
@@ -20,3 +20,11 @@ describe('entity spacing', () => {
         expect(cssText).toMatch(/\.entities-row \.entity \{[^}]*position: relative/);
     });
 });
+
+describe('toggle alignment', () => {
+    // HA's toggle host is display:flex with no horizontal alignment; without this it hugs the
+    // left edge of any slot wider than the switch (see #436).
+    it('centers ha-entity-toggle within its slot', () => {
+        expect(cssText).toMatch(/\.entity ha-entity-toggle \{[^}]*justify-content: center/);
+    });
+});


### PR DESCRIPTION
The 4.10.1 padding gap stacked with margins users set via `styles:`, widening tuned rows into overflow on phones (#432 regression report). Spacing is margin again — layout identical to 4.10.0 — with a layout-neutral `::after` extending each entity's hit area across the gap, and `position: relative` on entities so a later sibling wins hit-testing where a zero margin makes boxes overlap (no click-stealing).

Also centers `ha-entity-toggle` in its slot (#436): HA's host is `display:flex` with no horizontal alignment, so it hugged the left edge of any slot wider than the switch.

Testbed-verified (HA 2026.8.0): gap tap fires the adjacent entity's action; a user-style `margin-right` fully replaces the card's gap (zero stacking); neighbor clicks intact at `margin: 0`; toggle centered in a widened slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)