### PR TITLE
Templated styles, row color inheritance, secondary_info styles (#439, #441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**Added:**
+- `styles` values accept templates, on the row, additional entities and `secondary_info` - the way to color the displayed text by state. A pending declaration is dropped until its result lands; the rest apply (#439)
+
+**Changed:**
+- An additional entity without its own `color`/`state_color` now follows the row's, so `color: none` on the row restores the pre-4.9 look for the whole row. An explicit per-entity `color`, `state_color` or `icon_color` still wins (#441)
+
+**Fixed:**
+- `styles` on a `secondary_info` object had been silently ignored since 4.0.0 moved the secondary line into HA's row element; it applies again, as documented
+
 ## 4.10.2
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ running, and `mm:ss (Paused)` when paused. An explicit `attribute:` or `template
 | unit              | string/bool | `unit_of_measurement`       | Override entity unit of measurement (or `false` to hide)           |
 | toggle            | bool        | `false`                     | Display a toggle if supported by domain                            |
 | icon              | string/bool | `false`                     | Display default or custom icon instead of state or attribute value |
-| color             | string      | `state`                     | `state`, `none`, a theme color or a CSS color                      |
+| color             | string      | the row's `color`           | `state`, `none`, a theme color or a CSS color                      |
 | state_color       | bool        | _deprecated_                | Superseded by `color`                                              |
 | icon_color        | string      |                             | CSS color for the entity icon                                      |
 | state_icon        | object      |                             | Map of state value → icon override                                 |
@@ -246,7 +246,7 @@ For example, only show the alarm exit-state sensor while the alarm is armed:
 
 ### Templating
 
-Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `color`, `secondary_info` text, `hide_if`, a `template` option that replaces the displayed value entirely, and any value inside `tap_action`/`hold_action`/`double_tap_action`. The `entity` variable holds the owning entity's id, and `vars` lets you name values reused across a row.
+Display options accept Jinja **templates**, rendered by Home Assistant server-side and updated live whenever the entities they reference change. Any supported option whose value contains `{{ }}` or `{% %}` is treated as a template: `name`, `icon`, `icon_color`, `color`, `secondary_info` text, `hide_if`, a `template` option that replaces the displayed value entirely, any `styles` value, and any value inside `tap_action`/`hold_action`/`double_tap_action`. The `entity` variable holds the owning entity's id, and `vars` lets you name values reused across a row.
 
 ```yaml
 - type: custom:multiple-entity-row
@@ -263,7 +263,7 @@ See **[docs/templating.md](docs/templating.md)** for the full documentation: sup
 
 ### Icon styling
 
-`color` follows Home Assistant's icon color option and accepts `state` (color by entity state), `none` (never color), a theme color name (`red`, `deep-purple`, `accent`), or any CSS color. It applies to the main row icon and to additional entities rendering an icon. The default is `state`, matching the entities card:
+`color` follows Home Assistant's icon color option and accepts `state` (color by entity state), `none` (never color), a theme color name (`red`, `deep-purple`, `accent`), or any CSS color. It applies to the main row icon and to additional entities rendering an icon; an additional entity without its own `color` follows the row's. The default is `state`, matching the entities card:
 
 ```yaml
 - entity: light.kitchen

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -19,6 +19,7 @@ there is no separate `*_template` key.
 | `color`          | main row, additional entities                    | `state`, `none`, a theme color or a CSS color      |
 | `template`       | main row, additional entities, secondary         | Result replaces the displayed state value entirely |
 | `hide_if`        | as a plain string, or `hide_if.template`         | Hides when the result renders true                 |
+| `styles`         | main row, additional entities, secondary         | Each value is used as the CSS declaration's value  |
 | action configs   | `tap_action`, `hold_action`, `double_tap_action` | Any value inside them, at any depth                |
 
 ## Variables (`vars`)
@@ -150,6 +151,18 @@ all and re-evaluates when any of them change.
     - entity: binary_sensor.ferry_docked
       icon: "{{ 'mdi:ferry' if is_state(entity, 'on') else 'mdi:waves' }}"
       name: Dock
+```
+
+## Styles
+
+Any value inside `styles` can be a template, which is how the displayed text (rather than the icon) gets a state-dependent color. A pending declaration is left out until its result arrives; the others apply immediately.
+
+```yaml
+- type: custom:multiple-entity-row
+  entity: sensor.air_quality_label
+  styles:
+    color: "{{ 'green' if states('sensor.air_quality_index') | int(0) <= 50 else 'red' }}"
+    font-weight: bold
 ```
 
 ## Behavior details

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -52,6 +52,29 @@ describe('resolveColor', () => {
         expect(resolveColor({ icon_color: 'red', color: 'state' })).toEqual({ stateColor: true });
         expect(resolveColor({ icon_color: 'red', state_color: true })).toEqual({ stateColor: true });
     });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/441 - the row's color is
+    // the default for its sub-entities, so `color: none` on the row restores the pre-4.9 look.
+    describe('inherited scope', () => {
+        it('falls back to the inherited color or state_color', () => {
+            expect(resolveColor({}, { color: 'none' })).toEqual({ stateColor: false });
+            expect(resolveColor({}, { color: 'red' })).toEqual({ cssColor: 'var(--red-color)' });
+            expect(resolveColor({}, { state_color: false })).toEqual({ stateColor: false });
+        });
+
+        it('lets the entity override what it inherits', () => {
+            expect(resolveColor({ color: 'state' }, { color: 'none' })).toEqual({ stateColor: true });
+            expect(resolveColor({ state_color: true }, { color: 'none' })).toEqual({ stateColor: true });
+        });
+
+        it('does not inherit past an icon_color, which needs state coloring off', () => {
+            expect(resolveColor({ icon_color: 'red' }, { color: 'state' })).toEqual({ stateColor: false });
+        });
+
+        it('ignores the inherited icon_color - it paints that badge only', () => {
+            expect(resolveColor({}, { icon_color: 'red' })).toEqual({ stateColor: true });
+        });
+    });
 });
 
 describe('badgeColorProps', () => {

--- a/src/color.ts
+++ b/src/color.ts
@@ -44,17 +44,25 @@ export const computeCssColor = (color: string): string => (THEME_COLORS.has(colo
 
 export type ResolvedColor = { stateColor: boolean } | { cssColor: string };
 
+type ColorConfig = { color?: string; state_color?: boolean; icon_color?: string };
+
+// `color` wins, then the deprecated `state_color`; undefined when neither is set.
+const explicitColor = (config: ColorConfig): string | undefined =>
+    config.color ?? (config.state_color === undefined ? undefined : config.state_color ? 'state' : 'none');
+
 /**
  * Resolve a config's effective icon color into a form that can be handed to state-badge.
  *
- * `color` wins, then the deprecated `state_color`. With neither set the default is "state" (HA
- * 2026.8 colors entity rows by default) - EXCEPT when `icon_color` is configured, because that
- * option paints the icon through CSS variables and an inline state color would beat it, silently
- * dropping the user's color whenever the entity is active.
+ * `color` wins, then the deprecated `state_color`, then the same pair on `inherited` (the row,
+ * for a sub-entity - see #441: `color: none` on the row is documented as restoring the pre-4.9
+ * look, which it can only do if sub-entities follow it). With nothing set the default is
+ * "state" (HA 2026.8 colors entity rows by default) - EXCEPT when `icon_color` is configured,
+ * because that option paints the icon through CSS variables and an inline state color would
+ * beat it, silently dropping the user's color whenever the entity is active. The row's own
+ * `icon_color` is a paint on its badge only, so it is not inherited.
  */
-export const resolveColor = (config: { color?: string; state_color?: boolean; icon_color?: string }): ResolvedColor => {
-    const color =
-        config.color ?? (config.state_color === undefined ? undefined : config.state_color ? 'state' : 'none');
+export const resolveColor = (config: ColorConfig, inherited?: ColorConfig): ResolvedColor => {
+    const color = explicitColor(config) ?? (config.icon_color || !inherited ? undefined : explicitColor(inherited));
     if (color === undefined) {
         return config.icon_color ? { stateColor: false } : { stateColor: true };
     }

--- a/src/entity.js
+++ b/src/entity.js
@@ -328,9 +328,11 @@ export const entityStateDisplay = (hass, stateObj, config) => {
     return breakablePercent(hass.formatEntityState(modifiedStateObj));
 };
 
+// An empty value is a pending `styles` template - drop the declaration rather than emit `key: ;`.
 export const entityStyles = (config) =>
     isObject(config?.styles)
         ? Object.keys(config.styles)
+              .filter((key) => config.styles[key] !== '' && config.styles[key] != null)
               .map((key) => `${key}: ${config.styles[key]};`)
               .join('')
         : '';

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -397,6 +397,11 @@ describe('entityStyles', () => {
         expect(entityStyles({})).toBe('');
         expect(entityStyles(undefined)).toBe('');
     });
+
+    // A pending styles template resolves to '' - the declaration is dropped, not emitted empty.
+    it('skips declarations with an empty value', () => {
+        expect(entityStyles({ styles: { color: '', 'font-weight': 'bold', width: null } })).toBe('font-weight: bold;');
+    });
 });
 
 // See https://github.com/benct/lovelace-multiple-entity-row/issues/325

--- a/src/index.js
+++ b/src/index.js
@@ -249,7 +249,9 @@ class MultipleEntityRow extends LitElement {
             return null;
         }
         const name = entityName(this.info, config);
-        return html`${name} ${this.renderValue(this.info, config)}`;
+        // hui-generic-entity-row owns the secondary line, so `styles` can only reach the text
+        // through a wrapper of our own - it had been silently ignored here since 4.0.0.
+        return html`<span style="${entityStyles(config)}">${name} ${this.renderValue(this.info, config)}</span>`;
     }
 
     renderMainEntity() {
@@ -262,7 +264,7 @@ class MultipleEntityRow extends LitElement {
         // itself (name, icon, sub-entities) stays visible.
         if (hideIf(this.stateObj, config, this._hass)) {
             if (this.config.default) {
-                return html`<div class="state entity" style="${entityStyles(this.config)}">
+                return html`<div class="state entity" style="${entityStyles(config)}">
                     ${this.renderMainHeader()}
                     <div>${this.config.default}</div>
                 </div>`;
@@ -272,7 +274,7 @@ class MultipleEntityRow extends LitElement {
         const gesture = this.getGestureHandlers('main', this.config.entity, this.config);
         return html`<div
             class="state entity"
-            style="${entityStyles(this.config)}"
+            style="${entityStyles(config)}"
             @pointerdown="${gesture?.onDown}"
             @pointerup="${gesture?.onUp}"
             @pointercancel="${gesture?.onCancel}"
@@ -479,8 +481,9 @@ class MultipleEntityRow extends LitElement {
         const overrideIcon =
             stateIcon(stateObj, config) ?? (config.icon === true ? stateObj.attributes.icon || null : config.icon);
         // Exactly one of these is set (see badgeColorProps); the other stays undefined so
-        // state-badge falls through to the one that is.
-        const { stateColor, color } = badgeColorProps(resolveColor(config));
+        // state-badge falls through to the one that is. Only sub-entities render here (the main
+        // icon belongs to hui-generic-entity-row), so the row config is the inherited scope.
+        const { stateColor, color } = badgeColorProps(resolveColor(config, this._resolved(this.config)));
         // state-badge shows an entity picture instead of an icon when the entity has one and no
         // icon overrides it - and then it hides the icon and paints the picture as a background,
         // so the host needs its fixed box or there is nothing to give it height. Deciding that

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -844,6 +844,22 @@ describe('multiple-entity-row', () => {
             expect(spans.some((span) => span.textContent === 'restart on nas')).toBe(true);
         });
 
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/439
+        it('renders a templated styles value once its result lands', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                styles: { color: "{{ 'red' if is_state(entity, 'on') else 'green' }}", 'font-weight': 'bold' },
+            });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            const state = () => el.shadowRoot.querySelector('.state.entity').getAttribute('style');
+            // Pending: the other declarations apply, the templated one is absent.
+            expect(state()).toBe('font-weight: bold;');
+            connection.subs[0].callback({ result: 'red' });
+            await flushRender(el);
+            expect(state()).toBe('color: red;font-weight: bold;');
+        });
+
         // Gesture handlers are cached until the next setConfig, so an action config resolved at
         // render time would be frozen at whatever the first render saw - including a pending
         // result. Resolving at dispatch also means the service call carries current values.
@@ -926,6 +942,18 @@ describe('multiple-entity-row', () => {
             expect(row.secondaryText.values).toContain('5 min left');
         });
 
+        it('applies secondary_info styles, templated or not', async () => {
+            el.setConfig({
+                entity: 'sensor.main',
+                secondary_info: { entity: 'sensor.a', styles: { color: '{{ c }}', 'font-weight': 'bold' } },
+            });
+            el.hass = hassWith(states());
+            connection.subs[0].callback({ result: 'red' });
+            await flushRender(el);
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.secondaryText.values).toContain('color: red;font-weight: bold;');
+        });
+
         it('unsubscribes when the element is disconnected', async () => {
             el.setConfig({ entity: 'sensor.main', name: '{{ n }}' });
             el.hass = hassWith(states());
@@ -974,13 +1002,31 @@ describe('multiple-entity-row', () => {
             expect(await rowConfig({ state_color: false })).toMatchObject({ state_color: false });
         });
 
-        it('applies the resolved color to a sub-entity icon badge', async () => {
-            el.setConfig({ entity: 'sensor.main', entities: [{ entity: 'sensor.a', icon: true, color: 'blue' }] });
+        const subBadge = async (config) => {
+            el.setConfig({ entity: 'sensor.main', ...config });
             el.hass = buildHass(states());
             await flushRender(el);
-            const badge = el.shadowRoot.querySelector('.entity:not(.state) state-badge');
+            return el.shadowRoot.querySelector('.entity:not(.state) state-badge');
+        };
+
+        it('applies the resolved color to a sub-entity icon badge', async () => {
+            const badge = await subBadge({ entities: [{ entity: 'sensor.a', icon: true, color: 'blue' }] });
             expect(badge.color).toBe('var(--blue-color)');
             expect(badge.stateColor).toBeUndefined();
+        });
+
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/441
+        it('lets a sub-entity icon inherit the row color', async () => {
+            const badge = await subBadge({ color: 'none', entities: [{ entity: 'sensor.a', icon: true }] });
+            expect(badge.stateColor).toBe(false);
+        });
+
+        it('lets a sub-entity color override the row color', async () => {
+            const badge = await subBadge({
+                color: 'none',
+                entities: [{ entity: 'sensor.a', icon: true, color: 'state' }],
+            });
+            expect(badge.stateColor).toBe(true);
         });
     });
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -121,6 +121,19 @@ describe('collectTemplates', () => {
         ]);
     });
 
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/439
+    it('collects templated styles values', () => {
+        const requests = collectTemplates({
+            entity: 'sensor.main',
+            styles: { color: '{{ c }}', 'font-weight': 'bold' },
+            entities: [{ entity: 'sensor.a', styles: { width: '{{ w }}px' } }],
+        });
+        expect(requests).toEqual([
+            { template: '{{ c }}', entity: 'sensor.main' },
+            { template: '{{ w }}px', entity: 'sensor.a' },
+        ]);
+    });
+
     it('collects both hide_if template forms', () => {
         const requests = collectTemplates({
             entity: 'sensor.main',
@@ -332,6 +345,16 @@ describe('resolveTemplateFields', () => {
         expect(resolved.template).toBe('42');
         expect(resolved.icon).toBe('mdi:fan');
         expect(resolved.hide_if).toBe(true);
+    });
+
+    it('resolves templated styles per declaration, dropping a pending one', () => {
+        const config = { entity: 'sensor.a', styles: { color: '{{ c }}', 'font-size': '{{ s }}px', width: '10px' } };
+        const { connection, results } = buildManager(config);
+        connection.subs.find((sub) => sub.message.template === '{{ c }}')!.callback({ result: 'red' });
+        const resolved = resolveTemplateFields(config, results(), 'sensor.a');
+        expect(resolved.styles).toEqual({ color: 'red', 'font-size': '', width: '10px' });
+        // The source config is never mutated.
+        expect(config.styles.color).toBe('{{ c }}');
     });
 
     it('stringifies list/dict results as JSON instead of [object Object]', () => {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -150,6 +150,9 @@ export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
         add(entry.color, owner, prefix);
         add(entry.template, owner, prefix);
         add(hideIfTemplate(entry), owner, prefix);
+        if (isObject(entry.styles)) {
+            Object.values(entry.styles as LooseObject).forEach((value) => add(value, owner, prefix));
+        }
         ACTION_KEYS.forEach((key) => walkTemplates(entry[key], (template) => add(template, owner, prefix)));
     };
     const main = config.entity as string | undefined;
@@ -215,6 +218,17 @@ export const resolveTemplateFields = <T extends LooseObject>(
         // Collapse to the boolean verdict hideIf understands. Pending renders visible, matching
         // hide_if.entity's missing-reference behavior.
         patch('hide_if', isTruthyResult(get(hideTemplate)));
+    }
+    if (isObject(config.styles) && Object.values(config.styles as LooseObject).some(hasTemplate)) {
+        // Per-declaration: a pending one resolves to '' and entityStyles drops it, so the
+        // other declarations still apply while it is in flight (see #439).
+        const styles = Object.fromEntries(
+            Object.entries(config.styles as LooseObject).map(([key, value]) => [
+                key,
+                hasTemplate(value) ? displayResult(get(value)) : value,
+            ])
+        );
+        patch('styles', styles);
     }
     return resolved;
 };


### PR DESCRIPTION
Three related changes in the styling/colour area, all with tests and verified live on HA 2026.8.

- **`styles` values accept templates** on the row, additional entities and `secondary_info` (#439) — the way to colour the displayed *text* by state, which `color` (icons only) can't do. A pending declaration is dropped until its result lands; the rest apply immediately.
- **Additional entities inherit the row's `color`/`state_color`** unless they set `color`, `state_color` or `icon_color` (#441). Makes `color: none` on the row actually restore the pre-4.9 look for the whole row. The row's `icon_color` is deliberately not inherited — it paints that badge only. Listed under *Changed* since a row with `color: red` now tints its sub-entity icons too.
- **`styles` on a `secondary_info` object works again.** It's been silently ignored since 4.0.0 moved the secondary line into `hui-generic-entity-row`, despite the README example. Also fixes the main slot passing raw config to `entityStyles`, so main-row styles were never resolved.

Closes #439, closes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)