### PR TITLE
Add a state → color map form of state_color (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 **Added:**
 - `name_gap` - the spacing between the main icon and the row name, a CSS length or a number (px). HA hardcodes it at 16px inside its row element's shadow DOM, so it previously took card-mod's shadow-piercing `$`; unset rows are untouched. Contributed by @BlackZork (#401, #443)
+- `state_color` accepts a map of state value → color, overriding `color` for matching states the way `state_icon` overrides `icon`. A match is painted like `icon_color`, active or not, so an entry for `off` works. Static, so it costs no template subscription; the boolean form keeps working as the deprecated alias (#444)
 - `styles` values accept templates, on the row, additional entities and `secondary_info` - the way to color the displayed text by state. A pending declaration is dropped until its result lands; the rest apply (#439)
 
 **Changed:**

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The above configuration can be managed in the Configuration -> Dashboards -> Res
 
 This card produces an `entity-row` and must therefore be configured as an entity in an [entities](https://www.home-assistant.io/lovelace/entities/) card.
 
-A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, digit-suffixed formats like `precision5`, [templates](#templating)) are YAML-only — a config containing templates opens directly in the code editor.
+A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, `state_color` maps, digit-suffixed formats like `precision5`, [templates](#templating)) are YAML-only — a config containing templates opens directly in the code editor.
 
-> **Beta:** `name_gap`, templates in `styles`, and additional entities following the row's `color` ship in 4.11.0, currently available as a beta — enable *Show beta versions* on the card's HACS page to install it.
+> **Beta:** `name_gap`, templates in `styles`, `state_color` maps, and additional entities following the row's `color` ship in 4.11.0, currently available as a beta — enable *Show beta versions* on the card's HACS page to install it.
 
 | Name             | Type        | Default                     | Description                                      |
 | ---------------- | ----------- | --------------------------- | ------------------------------------------------ |
@@ -61,7 +61,7 @@ A **visual editor** is available: when editing a `custom:multiple-entity-row` ro
 | show_state_first | bool        | `false`                     | Show the main state before other entities        |
 | state_header     | string      |                             | Show header text above the main entity state     |
 | color            | string      | `state`                     | `state`, `none`, a theme color or a CSS color    |
-| state_color      | bool        | _deprecated_                | Superseded by `color`                            |
+| state_color      | object/bool | _[Colors](#icon-styling)_   | Map of state value → color; bool form deprecated |
 | column           | bool        | `false`                     | Show entities in a column instead of a row       |
 | wrap             | bool        | `false`                     | Wrap onto multiple lines instead of overflowing  |
 | align            | string      | `center`                    | Vertical alignment: `top`, `center` or `bottom`  |
@@ -106,7 +106,7 @@ running, and `mm:ss (Paused)` when paused. An explicit `attribute:` or `template
 | toggle            | bool        | `false`                     | Display a toggle if supported by domain                            |
 | icon              | string/bool | `false`                     | Display default or custom icon instead of state or attribute value |
 | color             | string      | the row's `color`           | `state`, `none`, a theme color or a CSS color                      |
-| state_color       | bool        | _deprecated_                | Superseded by `color`                                              |
+| state_color       | object/bool | _[Colors](#icon-styling)_   | Map of state value → color; bool form deprecated                   |
 | icon_color        | string      |                             | CSS color for the entity icon                                      |
 | state_icon        | object      |                             | Map of state value → icon override                                 |
 | default           | string      |                             | Display this value if the entity does not exist or is hidden       |
@@ -282,7 +282,20 @@ See **[docs/templating.md](docs/templating.md)** for the full documentation: sup
       color: none
 ```
 
-Theme color names and `state` require Home Assistant 2026.8 or newer for the main row icon; on older versions use `icon_color` there. `state_color` is still accepted as a deprecated alias — `true` means `color: state`, `false` means `color: none`.
+Theme color names and `state` require Home Assistant 2026.8 or newer for the main row icon; on older versions use `icon_color` there.
+
+`state_color` maps state values to colors, overriding `color` when the current state matches — the same relationship `state_icon` has to `icon`. A matched color is painted like `icon_color`, i.e. whether or not the entity is active, so an entry for `off` works; unmatched states fall back to `color`. Like `state_icon` it is matched on the raw state and belongs to the entity it is set on (additional entities do not inherit it), and being static it needs no template subscription:
+
+```yaml
+- entity: sensor.backup_status
+  color: var(--disabled-text-color)
+  state_color:
+    critical: var(--error-color)
+    warning: var(--warning-color)
+    ok: var(--success-color)
+```
+
+The boolean form of `state_color` is deprecated — `true` means `color: state`, `false` means `color: none`.
 
 `icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon **regardless of state**, which is the one thing `color` cannot express. Setting it also switches that entity's default to `color: none`, so the two do not fight; an explicit `color` still wins. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
 

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { badgeColorProps, computeCssColor, resolveColor, rowColorConfig } from './color';
+import { badgeColorProps, computeCssColor, mappedColor, resolveColor, rowColorConfig } from './color';
 
 describe('computeCssColor', () => {
     it('maps theme color names to their CSS variable', () => {
@@ -73,6 +73,41 @@ describe('resolveColor', () => {
 
         it('ignores the inherited icon_color - it paints that badge only', () => {
             expect(resolveColor({}, { icon_color: 'red' })).toEqual({ stateColor: true });
+        });
+    });
+
+    // See https://github.com/benct/lovelace-multiple-entity-row/issues/444 - a per-state color,
+    // as state_icon is a per-state icon. Static, so it costs no template subscription. A match
+    // is painted via CSS variables (mappedColor) and switches state coloring off here.
+    describe('state_color map', () => {
+        const map = { critical: 'red', warning: 'var(--warning-color)' };
+
+        it('turns state coloring off for a matching state, which mappedColor then paints', () => {
+            expect(resolveColor({ state_color: map }, undefined, 'critical')).toEqual({ stateColor: false });
+            expect(mappedColor({ state_color: map }, 'critical')).toBe('var(--red-color)');
+            expect(mappedColor({ state_color: map }, 'warning')).toBe('var(--warning-color)');
+        });
+
+        it('falls back to color, then the default, for an unmapped state', () => {
+            expect(mappedColor({ state_color: map }, 'ok')).toBeUndefined();
+            expect(resolveColor({ state_color: map, color: 'grey' }, undefined, 'ok')).toEqual({
+                cssColor: 'var(--grey-color)',
+            });
+            expect(resolveColor({ state_color: map }, undefined, 'ok')).toEqual({ stateColor: true });
+            expect(resolveColor({ state_color: map })).toEqual({ stateColor: true });
+        });
+
+        it('wins over color for a matching state', () => {
+            expect(resolveColor({ state_color: map, color: 'grey' }, undefined, 'critical')).toEqual({
+                stateColor: false,
+            });
+        });
+
+        it("is not inherited - it is keyed by the owning entity's states", () => {
+            expect(mappedColor({}, 'critical')).toBeUndefined();
+            expect(resolveColor({}, { state_color: map, color: 'grey' }, 'critical')).toEqual({
+                cssColor: 'var(--grey-color)',
+            });
         });
     });
 });

--- a/src/color.ts
+++ b/src/color.ts
@@ -44,24 +44,43 @@ export const computeCssColor = (color: string): string => (THEME_COLORS.has(colo
 
 export type ResolvedColor = { stateColor: boolean } | { cssColor: string };
 
-type ColorConfig = { color?: string; state_color?: boolean; icon_color?: string };
+type ColorConfig = { color?: string; state_color?: boolean | Record<string, string>; icon_color?: string };
 
-// `color` wins, then the deprecated `state_color`; undefined when neither is set.
+/**
+ * The `state_color` map entry for the current state as a CSS color, matched on the raw state
+ * like state_icon (see #444). Painted through the icon_color CSS variables rather than
+ * state-badge's `color`, because HA 2026.8 applies `color` only while the entity is active - a
+ * mapping for `off` would silently do nothing, and the point of a map is that every entry paints.
+ */
+export const mappedColor = (config: ColorConfig, state?: string): string | undefined => {
+    const color =
+        typeof config.state_color === 'object' && config.state_color !== null && state !== undefined
+            ? config.state_color[state]
+            : undefined;
+    return color === undefined ? undefined : computeCssColor(color);
+};
+
+// `color` wins, then the deprecated boolean `state_color`; undefined when neither is set. A
+// `state_color` map is deliberately not an "explicit color" here: it is keyed by this entity's
+// states, so it must not be inherited by sub-entities with different states.
 const explicitColor = (config: ColorConfig): string | undefined =>
-    config.color ?? (config.state_color === undefined ? undefined : config.state_color ? 'state' : 'none');
+    config.color ?? (typeof config.state_color === 'boolean' ? (config.state_color ? 'state' : 'none') : undefined);
 
 /**
  * Resolve a config's effective icon color into a form that can be handed to state-badge.
  *
- * `color` wins, then the deprecated `state_color`, then the same pair on `inherited` (the row,
- * for a sub-entity - see #441: `color: none` on the row is documented as restoring the pre-4.9
- * look, which it can only do if sub-entities follow it). With nothing set the default is
- * "state" (HA 2026.8 colors entity rows by default) - EXCEPT when `icon_color` is configured,
- * because that option paints the icon through CSS variables and an inline state color would
- * beat it, silently dropping the user's color whenever the entity is active. The row's own
- * `icon_color` is a paint on its badge only, so it is not inherited.
+ * A `state_color` map entry for the current `state` wins and, like `icon_color`, is painted
+ * through CSS variables - so state coloring is switched off here and the caller paints it (see
+ * mappedColor). Then `color`, then the deprecated boolean `state_color`, then the same pair on
+ * `inherited` (the row, for a sub-entity - see #441: `color: none` on the row is documented as
+ * restoring the pre-4.9 look, which it can only do if sub-entities follow it). With nothing set
+ * the default is "state" (HA 2026.8 colors entity rows by default) - EXCEPT when `icon_color` is
+ * configured, because that option paints the icon through CSS variables and an inline state
+ * color would beat it, silently dropping the user's color whenever the entity is active. The
+ * row's own `icon_color` is a paint on its badge only, so it is not inherited.
  */
-export const resolveColor = (config: ColorConfig, inherited?: ColorConfig): ResolvedColor => {
+export const resolveColor = (config: ColorConfig, inherited?: ColorConfig, state?: string): ResolvedColor => {
+    if (mappedColor(config, state) !== undefined) return { stateColor: false };
     const color = explicitColor(config) ?? (config.icon_color || !inherited ? undefined : explicitColor(inherited));
     if (color === undefined) {
         return config.icon_color ? { stateColor: false } : { stateColor: true };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { css, html, LitElement } from 'lit';
 import { LAST_CHANGED, LAST_UPDATED, TIMESTAMP_FORMATS } from './lib/constants';
 import { createGestureHandlers } from './lib/gesture_handler';
 import { defineElement } from './lib/define';
-import { badgeColorProps, resolveColor, rowColorConfig } from './color';
+import { badgeColorProps, mappedColor, resolveColor, rowColorConfig } from './color';
 import {
     checkEntity,
     entityName,
@@ -189,10 +189,14 @@ class MultipleEntityRow extends LitElement {
         // A state_icon match overrides the main row's icon by injecting it into the config
         // handed to hui-generic-entity-row, which owns the main icon rendering (see #197).
         const mainStateIcon = stateIcon(this.stateObj, config);
+        // The raw state_color is dropped: rowColorConfig re-expresses it, and a map (see #444)
+        // would otherwise reach state-badge as a truthy stateColor.
+        const rowBase = { ...config };
+        delete rowBase.state_color;
         const rowConfig = {
-            ...config,
+            ...rowBase,
             ...(mainStateIcon ? { icon: mainStateIcon } : {}),
-            ...rowColorConfig(resolveColor(config)),
+            ...rowColorConfig(resolveColor(config, undefined, this.stateObj.state)),
         };
 
         // catchInteraction must stay false: despite the name it does NOT control whether
@@ -214,7 +218,9 @@ class MultipleEntityRow extends LitElement {
         // it when there is no secondary info to lose.
         const hideName = this._nameHidden && !this.config.secondary_info;
         return html`<hui-generic-entity-row
-            style="${iconColorCss(config.icon_color)}${nameGapCss(config.name_gap)}"
+            style="${iconColorCss(mappedColor(config, this.stateObj.state) ?? config.icon_color)}${nameGapCss(
+                config.name_gap
+            )}"
             .hass="${this._hass}"
             .config="${rowConfig}"
             .secondaryText="${this.renderSecondaryInfo()}"
@@ -518,7 +524,9 @@ class MultipleEntityRow extends LitElement {
         // Exactly one of these is set (see badgeColorProps); the other stays undefined so
         // state-badge falls through to the one that is. Only sub-entities render here (the main
         // icon belongs to hui-generic-entity-row), so the row config is the inherited scope.
-        const { stateColor, color } = badgeColorProps(resolveColor(config, this._resolved(this.config)));
+        const { stateColor, color } = badgeColorProps(
+            resolveColor(config, this._resolved(this.config), stateObj.state)
+        );
         // state-badge shows an entity picture instead of an icon when the entity has one and no
         // icon overrides it - and then it hides the icon and paints the picture as a background,
         // so the host needs its fixed box or there is nothing to give it height. Deciding that
@@ -528,7 +536,7 @@ class MultipleEntityRow extends LitElement {
             !overrideIcon && !!(stateObj.attributes.entity_picture || stateObj.attributes.entity_picture_local);
         return html`<state-badge
             class="icon-small${hasPicture ? ' has-picture' : ''}"
-            style="${iconColorCss(config.icon_color)}"
+            style="${iconColorCss(mappedColor(config, stateObj.state) ?? config.icon_color)}"
             .hass=${this._hass}
             .stateObj="${stateObj}"
             .overrideIcon="${overrideIcon}"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1056,6 +1056,21 @@ describe('multiple-entity-row', () => {
             expect(badge.stateColor).toBe(false);
         });
 
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/444
+        // A mapped color is painted through the icon_color variables with state coloring off,
+        // so it applies to inactive states too (HA's `color` only paints active entities).
+        it('applies a state_color map to the main row and a sub-entity icon', async () => {
+            const badge = await subBadge({
+                state_color: { on: 'red' },
+                entities: [{ entity: 'sensor.a', icon: true, state_color: { on: 'blue', off: 'grey' } }],
+            });
+            expect(badge.stateColor).toBe(false);
+            expect(badge.getAttribute('style')).toContain('--state-icon-color: var(--blue-color)');
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.config.state_color).toBe(false);
+            expect(row.getAttribute('style')).toContain('--state-icon-color: var(--red-color)');
+        });
+
         it('lets a sub-entity color override the row color', async () => {
             const badge = await subBadge({
                 color: 'none',

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,8 +70,9 @@ interface EntityOptions {
     state_icon?: Record<string, string>;
     // "state" | "none" | a theme color name | any CSS color (HA 2026.8's color API; see color.ts).
     color?: string;
-    /** @deprecated superseded by `color`; true/false map to "state"/"none". */
-    state_color?: boolean;
+    /** A state → color map overriding `color` for matching states (see #444). The boolean form is
+     * deprecated: superseded by `color`, true/false map to "state"/"none". */
+    state_color?: boolean | Record<string, string>;
     toggle?: boolean;
     hide_unavailable?: boolean;
     hide_if?: any | any[] | HideIfObject;


### PR DESCRIPTION
`state_color` accepts a map of state → colour, overriding `color` for matching states the way `state_icon` overrides `icon`; the boolean form stays as the deprecated alias. Matched on the raw state, not inherited by sub-entities, static (no template subscription).

A match is painted through the `icon_color` CSS variables with state colouring off rather than via state-badge's `color` — HA 2026.8 applies `color` only while the entity is active, so an `off:` entry would otherwise do nothing. The raw key is stripped from the config handed to `hui-generic-entity-row` so the map never reaches state-badge as a truthy `stateColor`.

YAML-only for now; the visual editor's `state_icon` row UI would need generalising to offer it.

Closes #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)