### PR TITLE
Scope the main row's icon paint to the main badge (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `styles` values accept templates, on the row, additional entities and `secondary_info` - the way to color the displayed text by state. A pending declaration is dropped until its result lands; the rest apply (#439)
 
 **Changed:**
+- The main row's `icon_color` (and `state_color` map) no longer bleeds into additional entities' icons - it paints the main icon only, as documented. Sub-entity icons that relied on inheriting it need their own `icon_color` (#445)
 - An additional entity without its own `color`/`state_color` now follows the row's, so `color: none` on the row restores the pre-4.9 look for the whole row. An explicit per-entity `color`, `state_color` or `icon_color` still wins (#441)
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Theme color names and `state` require Home Assistant 2026.8 or newer for the mai
 
 The boolean form of `state_color` is deprecated — `true` means `color: state`, `false` means `color: none`.
 
-`icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon **regardless of state**, which is the one thing `color` cannot express. Setting it also switches that entity's default to `color: none`, so the two do not fight; an explicit `color` still wins. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
+`icon_color` accepts any CSS color value (`red`, `#ff0000`, `var(--my-color)`) and applies it to the entity's icon **regardless of state**, which is the one thing `color` cannot express. It paints only the entity it is set on - an additional entity that wants the row's color sets its own `icon_color`. Setting it also switches that entity's default to `color: none`, so the two do not fight; an explicit `color` still wins. `state_icon` maps state values to icon overrides, taking precedence over `icon` when the current state matches:
 
 ```yaml
 - entity: binary_sensor.front_door

--- a/src/entity.js
+++ b/src/entity.js
@@ -171,6 +171,12 @@ const stringTransform = (format, value) => {
 export const iconColorCss = (color) =>
     color ? `--paper-item-icon-color: ${color}; --mdc-icon-color: ${color}; --state-icon-color: ${color};` : '';
 
+// The main row's paint as a host variable consumed by the rule injectMainIconStyle puts inside
+// hui-generic-entity-row's shadow. Deliberately NOT iconColorCss on the host: custom properties
+// cascade into slotted children, so host-wide icon variables bleed into every sub-entity badge
+// that falls back to them (inactive, or color: none) with no way to undo it (see #445).
+export const mainIconColorCss = (color) => (color ? `--multiple-entity-row-main-icon-color: ${color};` : '');
+
 // A configured name_gap as the --multiple-entity-row-name-gap custom property, set on the
 // hui-generic-entity-row host so it cascades into that element's shadow, where index.js's injected
 // override reads it (core hardcodes the .info icon→name padding at 16px with no variable). A number

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import {
     entityStateDisplay,
     entityStyles,
     iconColorCss,
+    mainIconColorCss,
     nameGapCss,
     stateIcon,
 } from './entity';
@@ -36,6 +37,19 @@ import './timer_remaining';
 const stopBubble = (event) => event.stopPropagation();
 
 const NBSP = '\u00a0';
+
+// `:host .info` (specificity 0,2,0) is needed to beat core's own `.info` rule (0,1,0): Lit
+// puts core's `static styles` in adoptedStyleSheets, which the cascade orders *after* a
+// <style> appended to the shadow root, so an equal-specificity rule would lose. Higher
+// specificity wins regardless of order, and without !important a user override still wins.
+// Logical property only: a physical padding-left would pad the wrong (end) edge in RTL.
+const NAME_GAP_RULE = ':host .info{padding-inline-start:var(--multiple-entity-row-name-gap,16px)}';
+
+// Scopes the main row's icon_color / state_color-map paint to the main badge instead of setting
+// icon variables host-wide, which cascades into slotted sub-entity badges (see #445 and
+// mainIconColorCss). Class-gated so an unpainted row leaves the badge's theme fallbacks alone.
+const MAIN_ICON_RULE =
+    ':host(.main-icon-painted) state-badge{--paper-item-icon-color:var(--multiple-entity-row-main-icon-color);--mdc-icon-color:var(--multiple-entity-row-main-icon-color);--state-icon-color:var(--multiple-entity-row-main-icon-color)}';
 
 // `name: ' '` is the common idiom for "no header here" and must behave exactly like name:false,
 // so blank names collapse to null and go through the same headerPlaceholder path. #418 got this
@@ -217,10 +231,14 @@ class MultipleEntityRow extends LitElement {
         // (see #341, #365). HA renders secondary info inside that same box, though, so only hide
         // it when there is no secondary info to lose.
         const hideName = this._nameHidden && !this.config.secondary_info;
+        // The paint reaches only the main state-badge: a class-gated rule injected into the
+        // child's shadow (see injectMainIconStyle) reads the host variable set here. The class
+        // gate matters - with no paint the rule must not match at all, or the variable's absence
+        // would blank the badge's own theme fallbacks (see #445).
+        const mainPaint = mappedColor(config, this.stateObj.state) ?? config.icon_color;
         return html`<hui-generic-entity-row
-            style="${iconColorCss(mappedColor(config, this.stateObj.state) ?? config.icon_color)}${nameGapCss(
-                config.name_gap
-            )}"
+            class="${mainPaint ? 'main-icon-painted' : ''}"
+            style="${mainIconColorCss(mainPaint)}${nameGapCss(config.name_gap)}"
             .hass="${this._hass}"
             .config="${rowConfig}"
             .secondaryText="${this.renderSecondaryInfo()}"
@@ -258,20 +276,28 @@ class MultipleEntityRow extends LitElement {
     // variable), so a later name_gap change only updates the host variable via re-render - no re-inject.
     async updated(changedProps) {
         super.updated?.(changedProps);
-        if (this.config?.name_gap == null || this.config.name_gap === '') return;
         const row = this.renderRoot?.querySelector('hui-generic-entity-row');
         if (!row) return;
+        if (this.config?.name_gap != null && this.config.name_gap !== '') {
+            await this.injectRowStyle(row, 'data-mer-name-gap', NAME_GAP_RULE);
+        }
+        // Inject once the row first has a paint; from then on the :host class alone gates it, so
+        // a paint that comes and goes (a state_color map, a templated icon_color) needs no
+        // re-injection and an unpainted row keeps zero shadow modification.
+        if (this.renderRoot.querySelector('hui-generic-entity-row.main-icon-painted')) {
+            await this.injectRowStyle(row, 'data-mer-main-icon', MAIN_ICON_RULE);
+        }
+    }
+
+    // Inject a one-time scoped rule into hui-generic-entity-row's shadow. The rules are static
+    // (they read host variables), so later config changes only update the host via re-render.
+    async injectRowStyle(row, marker, rule) {
         await row.updateComplete;
         const root = row.shadowRoot;
-        if (!root || root.querySelector('style[data-mer-name-gap]')) return;
+        if (!root || root.querySelector(`style[${marker}]`)) return;
         const style = document.createElement('style');
-        style.setAttribute('data-mer-name-gap', '');
-        // `:host .info` (specificity 0,2,0) is needed to beat core's own `.info` rule (0,1,0): Lit
-        // puts core's `static styles` in adoptedStyleSheets, which the cascade orders *after* a
-        // <style> appended to the shadow root, so an equal-specificity rule would lose. Higher
-        // specificity wins regardless of order, and without !important a user override still wins.
-        // Logical property only: a physical padding-left would pad the wrong (end) edge in RTL.
-        style.textContent = ':host .info{padding-inline-start:var(--multiple-entity-row-name-gap,16px)}';
+        style.setAttribute(marker, '');
+        style.textContent = rule;
         root.appendChild(style);
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1068,7 +1068,29 @@ describe('multiple-entity-row', () => {
             expect(badge.getAttribute('style')).toContain('--state-icon-color: var(--blue-color)');
             const row = el.shadowRoot.querySelector('hui-generic-entity-row');
             expect(row.config.state_color).toBe(false);
-            expect(row.getAttribute('style')).toContain('--state-icon-color: var(--red-color)');
+            expect(row.getAttribute('style')).toContain('--multiple-entity-row-main-icon-color: var(--red-color)');
+            expect(row.classList.contains('main-icon-painted')).toBe(true);
+        });
+
+        // See https://github.com/benct/lovelace-multiple-entity-row/issues/445 - a host-wide
+        // icon variable cascades into every slotted sub-entity badge with no way to undo it, so
+        // the main paint travels as a dedicated variable scoped to the main badge instead.
+        it('keeps the main icon_color off the sub-entity badges', async () => {
+            const badge = await subBadge({ icon_color: 'purple', entities: [{ entity: 'sensor.a', icon: true }] });
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.getAttribute('style')).toContain('--multiple-entity-row-main-icon-color: purple');
+            expect(row.getAttribute('style')).not.toContain('--state-icon-color');
+            expect(row.classList.contains('main-icon-painted')).toBe(true);
+            expect(badge.getAttribute('style')).toBe('');
+        });
+
+        // The class gate is what protects theme fallbacks: with no paint the injected rule must
+        // not match, so the badge never sees an unset variable (see #445).
+        it('does not mark the row painted without an icon_color or state_color match', async () => {
+            await subBadge({ state_color: { off: 'red' }, entities: [{ entity: 'sensor.a', icon: true }] });
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.classList.contains('main-icon-painted')).toBe(false);
+            expect(row.getAttribute('style')).not.toContain('--multiple-entity-row-main-icon-color');
         });
 
         it('lets a sub-entity color override the row color', async () => {


### PR DESCRIPTION
Follow-up to #446.

Row-level `icon_color` set the three icon CSS variables on the `hui-generic-entity-row` host, and custom properties cascade into slotted children — so every sub-entity badge that fell back to them (inactive, or `color: none`) showed the row's paint, with no way to undo it (#445). #446's `state_color` map painted through the same path.

The paint now travels as a dedicated `--multiple-entity-row-main-icon-color` variable consumed by a class-gated rule injected into the child's shadow (the `name_gap` mechanism, refactored to share one injector). The class gate keeps the rule from matching on unpainted rows, so theme fallbacks are untouched. Verified live: leak gone, `color: none` sub-entities show defaults, `state_color` map still paints inactive states, `name_gap` unaffected.

Behaviour change, listed under Changed: sub-entity icons that relied on inheriting the row's `icon_color` now need their own.

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)