### PR TITLE
Fix color vs state_color precedence and harden the 4.11 edges (#444)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This card produces an `entity-row` and must therefore be configured as an entity
 
 A **visual editor** is available: when editing a `custom:multiple-entity-row` row through the entities card's UI editor, the row opens a form-based editor with tabs for the main entity and each additional entity (add / reorder / copy / paste / delete), plus sections for secondary info, state-based icons, per-entity custom CSS, and tap/hold/double-tap actions. Everything below can still be configured in YAML; a few advanced options (`hide_if`, `state_color` maps, digit-suffixed formats like `precision5`, [templates](#templating)) are YAML-only — a config containing templates opens directly in the code editor.
 
-> **Beta:** `name_gap`, templates in `styles`, `state_color` maps, and additional entities following the row's `color` ship in 4.11.0, currently available as a beta — enable *Show beta versions* on the card's HACS page to install it.
+> **Beta:** `name_gap`, templates in `styles`, `state_color` maps, `styles` on `secondary_info`, and additional entities following the row's `color` ship in 4.11.0, currently available as a beta — enable *Show beta versions* on the card's HACS page to install it.
 
 | Name             | Type        | Default                     | Description                                      |
 | ---------------- | ----------- | --------------------------- | ------------------------------------------------ |
@@ -284,7 +284,7 @@ See **[docs/templating.md](docs/templating.md)** for the full documentation: sup
 
 Theme color names and `state` require Home Assistant 2026.8 or newer for the main row icon; on older versions use `icon_color` there.
 
-`state_color` maps state values to colors, overriding `color` when the current state matches — the same relationship `state_icon` has to `icon`. A matched color is painted like `icon_color`, i.e. whether or not the entity is active, so an entry for `off` works; unmatched states fall back to `color`. Like `state_icon` it is matched on the raw state and belongs to the entity it is set on (additional entities do not inherit it), and being static it needs no template subscription:
+`state_color` maps state values to colors, overriding `color` when the current state matches — the same relationship `state_icon` has to `icon`. A matched color is painted like `icon_color`, i.e. whether or not the entity is active, so an entry for `off` works; unmatched states fall back to `color`. Like `state_icon` it is matched on the raw state and belongs to the entity it is set on (additional entities do not inherit it), and being static it needs no template subscription. In YAML-mode dashboards, quote `'on'`/`'off'` keys - unquoted, YAML 1.1 parses them as booleans and the entry never matches:
 
 ```yaml
 - entity: sensor.backup_status

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -88,6 +88,15 @@ describe('resolveColor', () => {
             expect(mappedColor({ state_color: map }, 'warning')).toBe('var(--warning-color)');
         });
 
+        it('treats null/empty map entries and prototype members as no entry', () => {
+            expect(mappedColor({ state_color: { on: null } as never }, 'on')).toBeUndefined();
+            expect(mappedColor({ state_color: { on: '' } }, 'on')).toBeUndefined();
+            expect(mappedColor({ state_color: { on: 'red' } }, 'constructor')).toBeUndefined();
+            expect(resolveColor({ state_color: { on: null } as never, color: 'red' }, undefined, 'on')).toEqual({
+                cssColor: 'var(--red-color)',
+            });
+        });
+
         it('falls back to color, then the default, for an unmapped state', () => {
             expect(mappedColor({ state_color: map }, 'ok')).toBeUndefined();
             expect(resolveColor({ state_color: map, color: 'grey' }, undefined, 'ok')).toEqual({

--- a/src/color.ts
+++ b/src/color.ts
@@ -6,6 +6,8 @@
 // than sniff hass.config.version, resolveColor() maps a config value onto the state-badge
 // properties that behave correctly on BOTH sides. See applyColor() for that mapping.
 
+import { stateMapValue } from './util';
+
 // Mirrors THEME_COLORS + YAML_ONLY_THEMES_COLORS in HA's src/common/color/compute-color.ts.
 const THEME_COLORS = new Set([
     'primary',
@@ -53,11 +55,8 @@ type ColorConfig = { color?: string; state_color?: boolean | Record<string, stri
  * mapping for `off` would silently do nothing, and the point of a map is that every entry paints.
  */
 export const mappedColor = (config: ColorConfig, state?: string): string | undefined => {
-    const color =
-        typeof config.state_color === 'object' && config.state_color !== null && state !== undefined
-            ? config.state_color[state]
-            : undefined;
-    return color === undefined ? undefined : computeCssColor(color);
+    const color = stateMapValue(config.state_color, state) as string | undefined;
+    return color === undefined ? undefined : computeCssColor(String(color));
 };
 
 // `color` wins, then the deprecated boolean `state_color`; undefined when neither is set. A

--- a/src/entity.js
+++ b/src/entity.js
@@ -1,6 +1,7 @@
 import { secondsToDuration } from './lib/seconds_to_duration';
 import { formatNumber } from './lib/format_number';
-import { isObject, isUnavailable } from './util';
+import { isObject, isUnavailable, stateMapValue } from './util';
+import { hasTemplate } from './templates';
 
 // An entry used to need one of entity/attribute/icon, on the reasoning that it would otherwise
 // render nothing. That stopped being true: an entry with no `entity` already falls back to the
@@ -171,7 +172,7 @@ const stringTransform = (format, value) => {
 export const iconColorCss = (color) =>
     color ? `--paper-item-icon-color: ${color}; --mdc-icon-color: ${color}; --state-icon-color: ${color};` : '';
 
-// The main row's paint as a host variable consumed by the rule injectMainIconStyle puts inside
+// The main row's paint as a host variable consumed by the rule injectRowStyle puts inside
 // hui-generic-entity-row's shadow. Deliberately NOT iconColorCss on the host: custom properties
 // cascade into slotted children, so host-wide icon variables bleed into every sub-entity badge
 // that falls back to them (inactive, or color: none) with no way to undo it (see #445).
@@ -182,12 +183,23 @@ export const mainIconColorCss = (color) => (color ? `--multiple-entity-row-main-
 // override reads it (core hardcodes the .info icon→name padding at 16px with no variable). A number
 // is treated as px; a string passes through ('8px', '0.5em', 'var(--x)'). `0` is a valid gap, so the
 // guard is `!= null` (and rejects only the empty string), not truthiness.
-export const nameGapCss = (gap) =>
-    gap != null && gap !== '' ? `--multiple-entity-row-name-gap: ${typeof gap === 'number' ? `${gap}px` : gap};` : '';
+// A number means px - and so does a numeric string, because the editor's name_gap field is a
+// text selector and can only save strings ('8' must behave like 8). Anything else that is not a
+// plausible CSS length - booleans, NaN, a Jinja template (name_gap is not a templated field) -
+// is treated as unset: a defined-but-invalid variable would suppress the injected rule's 16px
+// var() fallback and compute the padding to 0, silently collapsing the gap.
+export const nameGapCss = (gap) => {
+    let value = null;
+    if (typeof gap === 'number' && Number.isFinite(gap)) value = `${gap}px`;
+    else if (typeof gap === 'string' && gap.trim() !== '' && !hasTemplate(gap)) {
+        const text = gap.trim();
+        value = /^\d+(\.\d+)?$/.test(text) ? `${text}px` : text;
+    }
+    return value === null ? '' : `--multiple-entity-row-name-gap: ${value};`;
+};
 
 // The state_icon map's icon for the current state, or undefined (see #197).
-export const stateIcon = (stateObj, config) =>
-    isObject(config.state_icon) ? config.state_icon[stateObj.state] : undefined;
+export const stateIcon = (stateObj, config) => stateMapValue(config.state_icon, stateObj.state);
 
 export const entityName = (stateObj, config) => {
     if (config.name === false) return null;

--- a/src/entity.test.js
+++ b/src/entity.test.js
@@ -7,6 +7,7 @@ import {
     entityStyles,
     iconColorCss,
     stateIcon,
+    nameGapCss,
 } from './entity';
 import { NumberFormat } from './lib/constants';
 
@@ -401,6 +402,33 @@ describe('entityStyles', () => {
     // A pending styles template resolves to '' - the declaration is dropped, not emitted empty.
     it('skips declarations with an empty value', () => {
         expect(entityStyles({ styles: { color: '', 'font-weight': 'bold', width: null } })).toBe('font-weight: bold;');
+    });
+});
+
+// The editor's name_gap field is a text selector, so numeric strings must behave like numbers,
+// and anything that is not a usable CSS length must be treated as unset - a defined-but-invalid
+// variable suppresses the injected rule's 16px fallback and collapses the gap to 0.
+describe('nameGapCss', () => {
+    it('adds px to numbers and numeric strings', () => {
+        expect(nameGapCss(8)).toBe('--multiple-entity-row-name-gap: 8px;');
+        expect(nameGapCss('8')).toBe('--multiple-entity-row-name-gap: 8px;');
+        expect(nameGapCss(' 8.5 ')).toBe('--multiple-entity-row-name-gap: 8.5px;');
+        expect(nameGapCss(0)).toBe('--multiple-entity-row-name-gap: 0px;');
+    });
+
+    it('passes CSS lengths through', () => {
+        expect(nameGapCss('0.5em')).toBe('--multiple-entity-row-name-gap: 0.5em;');
+        expect(nameGapCss('var(--x)')).toBe('--multiple-entity-row-name-gap: var(--x);');
+    });
+
+    it('treats unusable values as unset', () => {
+        expect(nameGapCss(undefined)).toBe('');
+        expect(nameGapCss(null)).toBe('');
+        expect(nameGapCss('')).toBe('');
+        expect(nameGapCss(false)).toBe('');
+        expect(nameGapCss(true)).toBe('');
+        expect(nameGapCss(NaN)).toBe('');
+        expect(nameGapCss("{{ '8px' }}")).toBe('');
     });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,10 @@ const NAME_GAP_RULE = ':host .info{padding-inline-start:var(--multiple-entity-ro
 // Scopes the main row's icon_color / state_color-map paint to the main badge instead of setting
 // icon variables host-wide, which cascades into slotted sub-entity badges (see #445 and
 // mainIconColorCss). Class-gated so an unpainted row leaves the badge's theme fallbacks alone.
-const MAIN_ICON_RULE =
-    ':host(.main-icon-painted) state-badge{--paper-item-icon-color:var(--multiple-entity-row-main-icon-color);--mdc-icon-color:var(--multiple-entity-row-main-icon-color);--state-icon-color:var(--multiple-entity-row-main-icon-color)}';
+// Built from iconColorCss so the variable triple stays defined in exactly one place (#325).
+const MAIN_ICON_RULE = `:host(.main-icon-painted) state-badge{${iconColorCss(
+    'var(--multiple-entity-row-main-icon-color)'
+)}}`;
 
 // `name: ' '` is the common idiom for "no header here" and must behave exactly like name:false,
 // so blank names collapse to null and go through the same headerPlaceholder path. #418 got this
@@ -104,6 +106,8 @@ class MultipleEntityRow extends LitElement {
     constructor() {
         super();
         this._templateResults = new Map();
+        this._injected = new Set();
+        this._mainPainted = false;
         this._templates = new TemplateSubscriptions((results) => {
             this._templateResults = results;
         });
@@ -112,6 +116,12 @@ class MultipleEntityRow extends LitElement {
     connectedCallback() {
         super.connectedCallback();
         this._templates.connect();
+        // If hui-generic-entity-row's chunk lands after our first render (the frontend#52960
+        // load-order class), the injection pass in updated() found no shadowRoot and nothing
+        // re-triggers it - shouldUpdate swallows a bare requestUpdate(), so run it directly.
+        if (!customElements.get('hui-generic-entity-row')) {
+            customElements.whenDefined('hui-generic-entity-row').then(() => this.syncRowStyles());
+        }
     }
 
     disconnectedCallback() {
@@ -200,13 +210,21 @@ class MultipleEntityRow extends LitElement {
         if (!this.stateObj) return this.renderWarning();
 
         const config = this._resolved(this.config);
+        // Shared with renderMainEntity and renderIcon (the sub-entities' inherited color scope),
+        // which would otherwise each re-resolve the identical row config per render.
+        this._rowScope = config;
         // A state_icon match overrides the main row's icon by injecting it into the config
         // handed to hui-generic-entity-row, which owns the main icon rendering (see #197).
         const mainStateIcon = stateIcon(this.stateObj, config);
-        // The raw state_color is dropped: rowColorConfig re-expresses it, and a map (see #444)
-        // would otherwise reach state-badge as a truthy stateColor.
+        // The raw color and state_color are dropped: rowColorConfig re-expresses whichever
+        // applies. Left in, a map (see #444) would reach state-badge as a truthy stateColor, and
+        // a custom `color` would ride along on a map match and be painted inline by state-badge,
+        // beating the injected variables - so the map would never show (crowbarz, beta.2).
         const rowBase = { ...config };
-        delete rowBase.state_color;
+        delete rowBase.color;
+        // The boolean form stays: pre-2026.8 rows read ONLY state_color for their badge, and on
+        // 2026.8+ state-badge prefers `color` anyway, so precedence is preserved on both sides.
+        if (typeof rowBase.state_color !== 'boolean') delete rowBase.state_color;
         const rowConfig = {
             ...rowBase,
             ...(mainStateIcon ? { icon: mainStateIcon } : {}),
@@ -232,10 +250,11 @@ class MultipleEntityRow extends LitElement {
         // it when there is no secondary info to lose.
         const hideName = this._nameHidden && !this.config.secondary_info;
         // The paint reaches only the main state-badge: a class-gated rule injected into the
-        // child's shadow (see injectMainIconStyle) reads the host variable set here. The class
+        // child's shadow (see injectRowStyle) reads the host variable set here. The class
         // gate matters - with no paint the rule must not match at all, or the variable's absence
         // would blank the badge's own theme fallbacks (see #445).
         const mainPaint = mappedColor(config, this.stateObj.state) ?? config.icon_color;
+        this._mainPainted = !!mainPaint;
         return html`<hui-generic-entity-row
             class="${mainPaint ? 'main-icon-painted' : ''}"
             style="${mainIconColorCss(mainPaint)}${nameGapCss(config.name_gap)}"
@@ -274,31 +293,49 @@ class MultipleEntityRow extends LitElement {
     // render()), with a 16px fallback so the default is byte-for-byte unchanged. Gated on name_gap, so
     // rows that don't use it get zero shadow modification. The injected rule is static (reads the
     // variable), so a later name_gap change only updates the host variable via re-render - no re-inject.
-    async updated(changedProps) {
+    updated(changedProps) {
         super.updated?.(changedProps);
+        this.syncRowStyles();
+    }
+
+    syncRowStyles() {
+        // Cheap bail before any DOM query: most rows use neither feature. _mainPainted is set in
+        // render(); nameGapCss doubles as the "is a usable gap configured" predicate so the
+        // injection gate can never disagree with what render() emitted.
+        const gap = nameGapCss(this.config?.name_gap);
+        if (!gap && !this._mainPainted) return;
         const row = this.renderRoot?.querySelector('hui-generic-entity-row');
         if (!row) return;
-        if (this.config?.name_gap != null && this.config.name_gap !== '') {
-            await this.injectRowStyle(row, 'data-mer-name-gap', NAME_GAP_RULE);
-        }
+        if (gap) this.injectRowStyle(row, 'data-mer-name-gap', NAME_GAP_RULE);
         // Inject once the row first has a paint; from then on the :host class alone gates it, so
         // a paint that comes and goes (a state_color map, a templated icon_color) needs no
         // re-injection and an unpainted row keeps zero shadow modification.
-        if (this.renderRoot.querySelector('hui-generic-entity-row.main-icon-painted')) {
-            await this.injectRowStyle(row, 'data-mer-main-icon', MAIN_ICON_RULE);
+        if (row.classList.contains('main-icon-painted')) {
+            this.injectRowStyle(row, 'data-mer-main-icon', MAIN_ICON_RULE);
         }
     }
 
     // Inject a one-time scoped rule into hui-generic-entity-row's shadow. The rules are static
-    // (they read host variables), so later config changes only update the host via re-render.
+    // (they read host variables), so later config changes only update the host via re-render;
+    // _injected skips the await/query round on every update after the first successful one.
     async injectRowStyle(row, marker, rule) {
-        await row.updateComplete;
+        if (this._injected.has(marker)) return;
+        try {
+            await row.updateComplete;
+        } catch {
+            // The row's own update threw (broken child config, HA regression) - skip this pass
+            // rather than surface an unhandled rejection; the next update retries.
+            return;
+        }
         const root = row.shadowRoot;
-        if (!root || root.querySelector(`style[${marker}]`)) return;
-        const style = document.createElement('style');
-        style.setAttribute(marker, '');
-        style.textContent = rule;
-        root.appendChild(style);
+        if (!root) return;
+        if (!root.querySelector(`style[${marker}]`)) {
+            const style = document.createElement('style');
+            style.setAttribute(marker, '');
+            style.textContent = rule;
+            root.appendChild(style);
+        }
+        this._injected.add(marker);
     }
 
     renderSecondaryInfo() {
@@ -325,7 +362,7 @@ class MultipleEntityRow extends LitElement {
         if (this.config.show_state === false) {
             return null;
         }
-        const config = this._resolved(this.config);
+        const config = this._rowScope ?? this._resolved(this.config);
         // Top-level hide_if/hide_unavailable hide the main state slot, symmetrical to per-entity
         // behavior - previously they were silently ignored on the main entity (see #227). The row
         // itself (name, icon, sub-entities) stays visible.
@@ -550,9 +587,8 @@ class MultipleEntityRow extends LitElement {
         // Exactly one of these is set (see badgeColorProps); the other stays undefined so
         // state-badge falls through to the one that is. Only sub-entities render here (the main
         // icon belongs to hui-generic-entity-row), so the row config is the inherited scope.
-        const { stateColor, color } = badgeColorProps(
-            resolveColor(config, this._resolved(this.config), stateObj.state)
-        );
+        const inherited = this._rowScope ?? this._resolved(this.config);
+        const { stateColor, color } = badgeColorProps(resolveColor(config, inherited, stateObj.state));
         // state-badge shows an entity picture instead of an icon when the entity has one and no
         // icon overrides it - and then it hides the icon and paints the picture as a background,
         // so the host needs its fixed box or there is nothing to give it height. Deciding that

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1072,6 +1072,32 @@ describe('multiple-entity-row', () => {
             expect(row.classList.contains('main-icon-painted')).toBe(true);
         });
 
+        // A custom color must not ride along into the row config on a map match: state-badge
+        // paints .color inline, which would beat the injected variables (#444, beta.2 report).
+        it('drops the raw color from the row config when the state_color map matches', async () => {
+            await subBadge({ color: 'grey', state_color: { on: 'blue' }, entities: [{ entity: 'sensor.a' }] });
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.config.color).toBeUndefined();
+            expect(row.config.state_color).toBe(false);
+            expect(row.getAttribute('style')).toContain('--multiple-entity-row-main-icon-color: var(--blue-color)');
+        });
+
+        // Pre-2026.8 rows read ONLY state_color for their badge, so the boolean form must ride
+        // along with the computed color (2026.8's badge prefers color, so precedence holds).
+        it('keeps a boolean state_color beside a custom color in the row config', async () => {
+            await subBadge({ color: 'red', state_color: true, entities: [{ entity: 'sensor.a' }] });
+            const rowCfg = el.shadowRoot.querySelector('hui-generic-entity-row').config;
+            expect(rowCfg.color).toBe('var(--red-color)');
+            expect(rowCfg.state_color).toBe(true);
+        });
+
+        it('restores the custom color in the row config for an unmapped state', async () => {
+            await subBadge({ color: 'grey', state_color: { off: 'blue' }, entities: [{ entity: 'sensor.a' }] });
+            const row = el.shadowRoot.querySelector('hui-generic-entity-row');
+            expect(row.config.color).toBe('var(--grey-color)');
+            expect(row.classList.contains('main-icon-painted')).toBe(false);
+        });
+
         // See https://github.com/benct/lovelace-multiple-entity-row/issues/445 - a host-wide
         // icon variable cascades into every slotted sub-entity badge with no way to undo it, so
         // the main paint travels as a dedicated variable scoped to the main badge instead.

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -150,9 +150,7 @@ export const collectTemplates = (config: LooseObject): TemplateRequest[] => {
         add(entry.color, owner, prefix);
         add(entry.template, owner, prefix);
         add(hideIfTemplate(entry), owner, prefix);
-        if (isObject(entry.styles)) {
-            Object.values(entry.styles as LooseObject).forEach((value) => add(value, owner, prefix));
-        }
+        if (isObject(entry.styles)) walkTemplates(entry.styles, (template) => add(template, owner, prefix));
         ACTION_KEYS.forEach((key) => walkTemplates(entry[key], (template) => add(template, owner, prefix)));
     };
     const main = config.entity as string | undefined;
@@ -219,7 +217,7 @@ export const resolveTemplateFields = <T extends LooseObject>(
         // hide_if.entity's missing-reference behavior.
         patch('hide_if', isTruthyResult(get(hideTemplate)));
     }
-    if (isObject(config.styles) && Object.values(config.styles as LooseObject).some(hasTemplate)) {
+    if (isObject(config.styles) && configHasTemplates(config.styles)) {
         // Per-declaration: a pending one resolves to '' and entityStyles drops it, so the
         // other declarations still apply while it is in flight (see #439).
         const styles = Object.fromEntries(

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,16 @@ import { LAST_CHANGED, LAST_UPDATED, SECONDARY_INFO_VALUES, UNAVAILABLE_STATES }
 
 export const isObject = (obj) => typeof obj === 'object' && !Array.isArray(obj) && !!obj;
 
+// Own-property lookup for state → value maps (state_icon, state_color). A bare index walks the
+// prototype chain, so a state literally named 'constructor' or 'toString' would return an
+// Object.prototype member; and a null/empty entry (YAML `on:` with no value) is "no entry",
+// not a match - callers treat a match as authoritative and would otherwise render nothing.
+export const stateMapValue = (map, state) => {
+    if (!isObject(map) || state === undefined || !Object.prototype.hasOwnProperty.call(map, state)) return undefined;
+    const value = map[state];
+    return value == null || value === '' ? undefined : value;
+};
+
 // bubbles + composed so the event crosses our shadow root up to HA's root-level listener.
 export const fireEvent = (node, type, detail) => {
     const event = new Event(type, { bubbles: true, composed: true });

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -7,7 +7,27 @@ import {
     hideUnavailable,
     isObject,
     isUnavailable,
+    stateMapValue,
 } from './util';
+
+describe('stateMapValue', () => {
+    it('returns the own entry for a state', () => {
+        expect(stateMapValue({ on: 'red' }, 'on')).toBe('red');
+    });
+
+    it('ignores prototype members, arrays and non-maps', () => {
+        expect(stateMapValue({ on: 'red' }, 'constructor')).toBeUndefined();
+        expect(stateMapValue({ on: 'red' }, 'toString')).toBeUndefined();
+        expect(stateMapValue(['red', 'green'], '0')).toBeUndefined();
+        expect(stateMapValue(true, 'on')).toBeUndefined();
+        expect(stateMapValue(undefined, 'on')).toBeUndefined();
+    });
+
+    it('treats null and empty entries as no entry', () => {
+        expect(stateMapValue({ on: null }, 'on')).toBeUndefined();
+        expect(stateMapValue({ on: '' }, 'on')).toBeUndefined();
+    });
+});
 
 describe('isObject', () => {
     it('is true for plain objects', () => {


### PR DESCRIPTION
Fixes crowbarz's beta.2 report on #444 — with both `color` and a `state_color` map on the main row, the raw `color` rode along into HA's row config and its inline paint beat the injected variables, so a map match never showed. The row config now takes its colour keys from `rowColorConfig` alone, except the boolean `state_color`, which is kept: pre-2026.8 rows read only `state_color` for their badge, and 2026.8's badge prefers `color`, so precedence holds on both sides.

Also lands the pre-release review's confirmed findings:

- Shadow-rule injection retries via `customElements.whenDefined` when `hui-generic-entity-row` upgrades late (a bare `requestUpdate` is swallowed by `shouldUpdate`), tolerates a rejecting `updateComplete`, and skips the await/query round once injected.
- `name_gap` values are validated: numeric strings get `px` (the editor's text selector always saves strings), booleans/NaN/templates are treated as unset — each previously produced a defined-but-invalid variable that suppressed the 16px fallback and collapsed the gap to 0.
- `state_icon`/`state_color` lookups go through a shared own-property helper: no prototype-chain hits for states named like Object members, arrays rejected, null/empty entries are "no entry" instead of a match that paints nothing.
- Docs: quote `'on'`/`'off'` map keys (YAML 1.1 parses them as booleans in YAML-mode dashboards); `secondary_info.styles` added to the beta callout.
- Cleanups from the review: single-source gates for injection, `MAIN_ICON_RULE` built from `iconColorCss`, template collection reusing `walkTemplates`/`configHasTemplates`, row config resolved once per render instead of per badge.

343 tests; regression-verified live (map precedence, `name_gap`, #445 scoping, templated styles, `ha-form` round-trip of map keys checked in the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)