### PR TITLE
Pass secondary_info strings as plain text; re-inject swept styles (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**Fixed:**
+- A templated string `secondary_info` is now handed to HA's row element as a plain string instead of a rendered template fragment. When anything else mutates the row's DOM (a browser extension, a page translator), the old form made HA's renderer crash on every template update - each crash triggering HA's error reporter and burning CPU (#450)
+- `name_gap` and the main icon paint survive an entity temporarily disappearing: HA's row element sweeps its shadow DOM when it swaps to the "entity not found" warning and back, which silently removed the card's injected style rules until a full reload
+
 ## 4.11.0
 
 **Added:**

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,6 @@ class MultipleEntityRow extends LitElement {
     constructor() {
         super();
         this._templateResults = new Map();
-        this._injected = new Set();
         this._mainPainted = false;
         this._templates = new TemplateSubscriptions((results) => {
             this._templateResults = results;
@@ -315,11 +314,14 @@ class MultipleEntityRow extends LitElement {
         }
     }
 
-    // Inject a one-time scoped rule into hui-generic-entity-row's shadow. The rules are static
-    // (they read host variables), so later config changes only update the host via re-render;
-    // _injected skips the await/query round on every update after the first successful one.
+    // Inject a scoped rule into hui-generic-entity-row's shadow. The rules are static (they read
+    // host variables), so later config changes only update the host via re-render. Presence in the
+    // DOM is the only "already injected" state worth trusting: the row's lit render owns its shadow
+    // root to the end (no end marker), so a root template swap - the entity blipping away swaps
+    // both our template and the row's own to a warning and back - silently sweeps injected styles
+    // out with the old tree, and a cached flag would then block the re-inject forever (#450 audit).
     async injectRowStyle(row, marker, rule) {
-        if (this._injected.has(marker)) return;
+        if (row.shadowRoot?.querySelector(`style[${marker}]`)) return;
         try {
             await row.updateComplete;
         } catch {
@@ -335,7 +337,6 @@ class MultipleEntityRow extends LitElement {
             style.textContent = rule;
             root.appendChild(style);
         }
-        this._injected.add(marker);
     }
 
     renderSecondaryInfo() {
@@ -344,9 +345,19 @@ class MultipleEntityRow extends LitElement {
             return null;
         }
         if (typeof secondaryInfo === 'string') {
-            return html`${hasTemplate(secondaryInfo)
-                ? templateDisplay(this._templateResults, secondaryInfo, this.config.entity, scopeVars(this.config))
-                : secondaryInfo}`;
+            // A plain string, never an html`` wrapper: hui-generic-entity-row types secondaryText
+            // as a string, and a TemplateResult from our own lit makes HA's lit re-walk the nested
+            // part's DOM on every value change - if anything else (an extension, a translator) has
+            // mutated that DOM, every subsequent update throws, and HA's frontend source-maps each
+            // uncaught error at ~600ms a pop (see #450). A string commits once and then updates via
+            // textNode.data, touching no surrounding DOM. Falsy secondaryText makes the generic row
+            // fall back to config.secondary_info - the raw Jinja source - so pad '' to a space.
+            if (!hasTemplate(secondaryInfo)) {
+                return secondaryInfo;
+            }
+            return (
+                templateDisplay(this._templateResults, secondaryInfo, this.config.entity, scopeVars(this.config)) || ' '
+            );
         }
         const config = this._resolved(secondaryInfo);
         if (hideIf(this.info, config, this._hass)) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -115,8 +115,8 @@ describe('multiple-entity-row', () => {
 
     // name_gap sets a --multiple-entity-row-name-gap custom property on the hui-generic-entity-row
     // host; the actual `.info` padding override is injected into that (real) element's shadow at
-    // runtime (see updated() in index.js), which the jsdom stub row can't exercise - so these cover
-    // the host-variable half, and the injection is verified live on the target dashboard.
+    // runtime (see updated() in index.js). The stub row has no shadow of its own, so the injection
+    // test below attaches one; the rule's live effect is verified on the target dashboard.
     describe('name_gap', () => {
         const renderWith = async (config) => {
             el.setConfig({ entity: 'sensor.main', ...config });
@@ -145,6 +145,27 @@ describe('multiple-entity-row', () => {
 
         it('omits the variable when name_gap is not configured', async () => {
             expect((await renderWith({})).getAttribute('style') ?? '').not.toContain('--multiple-entity-row-name-gap');
+        });
+
+        // The injection half: jsdom's stub row has no shadow root of its own, so attach one and
+        // verify the rule lands - and lands again after being swept, which happens for real when
+        // the row's root template swaps to a warning and back on an entity blip (#450 audit).
+        it('injects the name_gap rule once and re-injects after the row shadow is swept', async () => {
+            const rerender = async (state) => {
+                el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state, attributes: {} } });
+                await flushRender(el);
+                // injectRowStyle awaits row.updateComplete (undefined on the stub) before appending.
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            };
+            const row = await renderWith({ name_gap: 8 });
+            row.attachShadow({ mode: 'open' });
+            await rerender('2');
+            expect(row.shadowRoot.querySelectorAll('style[data-mer-name-gap]')).toHaveLength(1);
+            await rerender('3');
+            expect(row.shadowRoot.querySelectorAll('style[data-mer-name-gap]')).toHaveLength(1);
+            row.shadowRoot.innerHTML = '';
+            await rerender('4');
+            expect(row.shadowRoot.querySelectorAll('style[data-mer-name-gap]')).toHaveLength(1);
         });
     });
 
@@ -812,6 +833,13 @@ describe('multiple-entity-row', () => {
 
     // 4.8.0 templating: supported config strings containing {{ }} render server-side via a
     // render_template websocket subscription (see #409 and the module comment in templates.ts).
+    it('passes a plain secondary_info string through to the generic row untouched', async () => {
+        el.setConfig({ entity: 'sensor.main', secondary_info: 'hello' });
+        el.hass = buildHass({ 'sensor.main': { entity_id: 'sensor.main', state: 'on', attributes: {} } });
+        await flushRender(el);
+        expect(el.shadowRoot.querySelector('hui-generic-entity-row').secondaryText).toBe('hello');
+    });
+
     describe('templating', () => {
         let connection;
 
@@ -968,13 +996,33 @@ describe('multiple-entity-row', () => {
             expect(el.shadowRoot.querySelector('hui-generic-entity-row').config.name).toBe('Row Name');
         });
 
-        it('renders a templated secondary_info string', async () => {
+        // secondaryText carries a plain string, never an html`` wrapper: HA types the property
+        // as a string, and a foreign TemplateResult makes HA's lit re-walk our nested DOM on
+        // every changed result - the #450 crash cascade when anything else mutates that DOM.
+        it('passes a templated secondary_info to the generic row as a plain string', async () => {
             el.setConfig({ entity: 'sensor.main', secondary_info: '{{ s }}' });
             el.hass = hassWith(states());
             connection.subs[0].callback({ result: '5 min left' });
             await flushRender(el);
             const row = el.shadowRoot.querySelector('hui-generic-entity-row');
-            expect(row.secondaryText.values).toContain('5 min left');
+            expect(row.secondaryText).toBe('5 min left');
+        });
+
+        // Falsy secondaryText makes hui-generic-entity-row fall back to config.secondary_info -
+        // for a templated string that is the raw Jinja source - so pending/empty pads to a space.
+        it('renders a space while a secondary_info template is pending', async () => {
+            el.setConfig({ entity: 'sensor.main', secondary_info: '{{ s }}' });
+            el.hass = hassWith(states());
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('hui-generic-entity-row').secondaryText).toBe(' ');
+        });
+
+        it('renders a space when a secondary_info template resolves empty', async () => {
+            el.setConfig({ entity: 'sensor.main', secondary_info: '{{ s }}' });
+            el.hass = hassWith(states());
+            connection.subs[0].callback({ result: '' });
+            await flushRender(el);
+            expect(el.shadowRoot.querySelector('hui-generic-entity-row').secondaryText).toBe(' ');
         });
 
         it('applies secondary_info styles, templated or not', async () => {


### PR DESCRIPTION
Fixes the #450 CPU-burn class: a templated string `secondary_info` is now passed to `hui-generic-entity-row` as a plain string instead of a cross-bundle TemplateResult, so HA's lit never re-walks our nested DOM when results change — the crash cascade when an extension or translator has mutated the row's DOM. A pending/empty result pads to `' '` so the generic row can't fall back to showing raw Jinja.

Also: injected `name_gap`/main-icon rules now self-heal. HA's row sweeps its shadow when swapping to the entity-not-found warning and back, which silently removed them; DOM presence now gates injection instead of a cached flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
